### PR TITLE
fix(mdbook-htmx): add logs volume for readOnlyRootFilesystem

### DIFF
--- a/charts/mdbook-htmx/templates/deployment.yaml
+++ b/charts/mdbook-htmx/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               mountPath: /tmp
             - name: cache
               mountPath: /var/cache/nginx
+            - name: logs
+              mountPath: /var/log/nginx
       volumes:
         - name: content
           {{- if .Values.contentConfigMap }}
@@ -72,6 +74,8 @@ spec:
         - name: tmp
           emptyDir: {}
         - name: cache
+          emptyDir: {}
+        - name: logs
           emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Summary
- Added emptyDir volume mount for `/var/log/nginx`
- Nginx can now write logs with `readOnlyRootFilesystem: true`

## Context
The helm-install CI job in mdbook-htmx was failing because nginx couldn't write logs to `/var/log/nginx` when `readOnlyRootFilesystem: true` is set in the security context.

## Test plan
- [ ] Helm lint passes
- [ ] Helm install in kind cluster succeeds
- [ ] Health check endpoint responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)