### PR TITLE
fix(ci): fix boolean comparison in publish-ghcr signing condition

### DIFF
--- a/.github/workflows/publish-ghcr.yaml
+++ b/.github/workflows/publish-ghcr.yaml
@@ -11,7 +11,7 @@ on:
       sign:
         description: 'Sign with Cosign'
         required: false
-        default: 'true'
+        default: true
         type: boolean
 
 permissions:
@@ -43,7 +43,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Cosign
-        if: inputs.sign == 'true'
+        if: inputs.sign
         uses: sigstore/cosign-installer@v3
 
       - name: Publish charts to GHCR
@@ -83,7 +83,7 @@ jobs:
           done
 
       - name: Sign charts with Cosign
-        if: inputs.sign == 'true'
+        if: inputs.sign
         run: |
           CHARTS_INPUT="${{ inputs.charts }}"
 


### PR DESCRIPTION
## Summary
Two fixes for the `publish-ghcr` workflow signing:

### Fix 1: Boolean comparison
The workflow input `sign` has `type: boolean`, but the conditions used string comparison:
```yaml
if: inputs.sign == 'true'  # Boolean compared to string = always false!
```

**Fix**: Changed to `if: inputs.sign` (use boolean directly)

### Fix 2: Sign by digest instead of tag
Cosign warns when signing by tag (e.g., `chart:0.2.1`) because the tag could point to a different image between push and sign. This is a security concern.

**Fix**: Capture digest from `helm push` output and sign using `chart@sha256:...`

Also updated `release-please.yaml` with the same digest-based signing.

## Test plan
- [ ] Run workflow: `gh workflow run publish-ghcr.yaml -f charts=all -f sign=true`
- [ ] Verify "Install Cosign" step runs
- [ ] Verify signing uses digest format (no deprecation warning)
- [ ] Confirm charts are signed in GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)