### PR TITLE
fix(ci): sign OCI artifacts by digest instead of tag

### DIFF
--- a/.github/workflows/publish-ghcr.yaml
+++ b/.github/workflows/publish-ghcr.yaml
@@ -46,9 +46,10 @@ jobs:
         if: inputs.sign
         uses: sigstore/cosign-installer@v3
 
-      - name: Publish charts to GHCR
+      - name: Publish and sign charts to GHCR
         run: |
           CHARTS_INPUT="${{ inputs.charts }}"
+          SIGN="${{ inputs.sign }}"
 
           if [ "$CHARTS_INPUT" = "all" ]; then
             CHART_DIRS=$(find charts -maxdepth 1 -mindepth 1 -type d)
@@ -76,37 +77,19 @@ jobs:
               helm package "$chart" -d .cr-release-packages/
 
               echo "🚀 Pushing $chart_name:$version to GHCR..."
-              helm push ".cr-release-packages/${chart_name}-${version}.tgz" oci://$REGISTRY
+              push_output=$(helm push ".cr-release-packages/${chart_name}-${version}.tgz" oci://$REGISTRY 2>&1)
+              echo "$push_output"
 
-              echo "✅ Published $chart_name:$version"
-            fi
-          done
+              # Extract digest from helm push output (format: "Digest: sha256:...")
+              digest=$(echo "$push_output" | grep -oP 'Digest: \Ksha256:[a-f0-9]+')
+              echo "✅ Published $chart_name:$version (digest: $digest)"
 
-      - name: Sign charts with Cosign
-        if: inputs.sign
-        run: |
-          CHARTS_INPUT="${{ inputs.charts }}"
-
-          if [ "$CHARTS_INPUT" = "all" ]; then
-            CHART_DIRS=$(find charts -maxdepth 1 -mindepth 1 -type d)
-          else
-            CHART_DIRS=""
-            IFS=',' read -ra CHART_NAMES <<< "$CHARTS_INPUT"
-            for name in "${CHART_NAMES[@]}"; do
-              name=$(echo "$name" | xargs)
-              if [ -d "charts/$name" ]; then
-                CHART_DIRS="$CHART_DIRS charts/$name"
+              # Sign by digest (not tag) for security
+              if [ "$SIGN" = "true" ] && [ -n "$digest" ]; then
+                echo "🔏 Signing $REGISTRY/${chart_name}@${digest}..."
+                cosign sign --yes "$REGISTRY/${chart_name}@${digest}"
+                echo "✅ Signed $chart_name:$version"
               fi
-            done
-          fi
-
-          for chart in $CHART_DIRS; do
-            if [ -f "$chart/Chart.yaml" ]; then
-              chart_name=$(grep '^name:' "$chart/Chart.yaml" | awk '{print $2}')
-              version=$(grep '^version:' "$chart/Chart.yaml" | awk '{print $2}')
-              echo "🔏 Signing $chart_name:$version..."
-              cosign sign --yes $REGISTRY/${chart_name}:${version}
-              echo "✅ Signed $chart_name:$version"
             fi
           done
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -102,9 +102,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # ============================================================
-      # 3. GHCR / GitHub Packages (OCI Registry)
+      # 3. GHCR / GitHub Packages (OCI Registry) + Sign by Digest
       # ============================================================
-      - name: Push charts to GHCR
+      - name: Push and sign charts to GHCR
         run: |
           for chart in charts/*/; do
             if [ -f "$chart/Chart.yaml" ]; then
@@ -112,36 +112,34 @@ jobs:
               version=$(grep '^version:' "$chart/Chart.yaml" | awk '{print $2}')
               tgz_file=".cr-release-packages/${chart_name}-${version}.tgz"
 
-              if [ -f "$tgz_file" ]; then
-                echo "🚀 Pushing $chart_name:$version to GHCR..."
-                helm push "$tgz_file" oci://$REGISTRY
-                echo "✅ Published $chart_name:$version to GHCR"
-              else
+              # Package if needed
+              if [ ! -f "$tgz_file" ]; then
                 echo "📦 Packaging $chart_name:$version..."
                 helm package "$chart" -d .cr-release-packages/
-                helm push ".cr-release-packages/${chart_name}-${version}.tgz" oci://$REGISTRY
-                echo "✅ Published $chart_name:$version to GHCR"
+              fi
+
+              # Push and capture digest
+              echo "🚀 Pushing $chart_name:$version to GHCR..."
+              push_output=$(helm push "$tgz_file" oci://$REGISTRY 2>&1)
+              echo "$push_output"
+
+              # Extract digest from helm push output (format: "Digest: sha256:...")
+              digest=$(echo "$push_output" | grep -oP 'Digest: \Ksha256:[a-f0-9]+')
+              echo "✅ Published $chart_name:$version (digest: $digest)"
+
+              # Sign by digest (not tag) for security
+              if [ -n "$digest" ]; then
+                echo "🔏 Signing $REGISTRY/${chart_name}@${digest}..."
+                cosign sign --yes "$REGISTRY/${chart_name}@${digest}"
+                echo "✅ Signed $chart_name:$version on GHCR"
+              else
+                echo "⚠️ Could not extract digest, skipping signing for $chart_name:$version"
               fi
             fi
           done
 
       # ============================================================
-      # 4. Sign GHCR OCI artifacts
-      # ============================================================
-      - name: Sign GHCR charts with Cosign
-        run: |
-          for chart in charts/*/; do
-            if [ -f "$chart/Chart.yaml" ]; then
-              chart_name=$(grep '^name:' "$chart/Chart.yaml" | awk '{print $2}')
-              version=$(grep '^version:' "$chart/Chart.yaml" | awk '{print $2}')
-              echo "🔏 Signing GHCR artifact: $REGISTRY/${chart_name}:${version}"
-              cosign sign --yes "$REGISTRY/${chart_name}:${version}"
-              echo "✅ Signed $chart_name:$version on GHCR"
-            fi
-          done
-
-      # ============================================================
-      # 5. Generate build attestations
+      # 4. Generate build attestations
       # ============================================================
       - name: Generate attestations for chart packages
         uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
## Summary
Fixes Cosign deprecation warning by signing OCI artifacts by digest instead of tag.

## Problem
Cosign warns when signing by tag (e.g., `chart:0.2.1`):
```
WARNING: Image reference ghcr.io/arustydev/charts/mdbook-htmx:0.2.1 uses a tag, not a digest...
```

Signing by tag is a security concern because the tag could point to a different image between push and sign operations.

## Solution
- Capture digest from `helm push` output (format: `Digest: sha256:...`)
- Sign using `chart@sha256:abc123...` instead of `chart:version`
- Combined push and sign into single step for atomic operation

## Changes
- `publish-ghcr.yaml` - Combined publish + sign, uses digest
- `release-please.yaml` - Combined push + sign, uses digest

## Test plan
- [ ] Run: `gh workflow run publish-ghcr.yaml -f charts=all -f sign=true`
- [ ] Verify no Cosign deprecation warning
- [ ] Verify signing uses digest format in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)