### PR TITLE
fix(ci): use GitHub App token for release-please PRs

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -19,10 +19,20 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       paths_released: ${{ steps.release.outputs.paths_released }}
     steps:
+      # Generate a token from the GitHub App to create PRs that trigger workflows
+      # PRs created by GITHUB_TOKEN don't trigger workflows (GitHub security feature)
+      # See: https://github.com/aRustyDev/helm-charts/issues/39
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ secrets.X_REPO_AUTH_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary
Fix release-please PRs having pending required checks that never start.

## Problem
PRs created by `GITHUB_TOKEN` don't trigger other workflows - this is a GitHub security feature to prevent infinite loops. This causes release-please PRs to sit with "Expected" checks that never run.

## Solution
Use a GitHub App token instead of `GITHUB_TOKEN` for release-please. PRs created by GitHub Apps DO trigger workflows.

## Required Setup (before merging)

### 1. Install the GitHub App
Ensure [x-repo-auth](https://github.com/apps/x-repo-auth) is installed on this repository.

### 2. Generate a Private Key
1. Go to https://github.com/settings/apps/x-repo-auth
2. Scroll to "Private keys" section
3. Click "Generate a private key"
4. Save the downloaded `.pem` file

### 3. Add Repository Secret
1. Go to https://github.com/aRustyDev/helm-charts/settings/secrets/actions
2. Click "New repository secret"
3. Name: `X_REPO_AUTH_PRIVATE_KEY`
4. Value: Paste the entire contents of the `.pem` file

### 4. Add Repository Variable
1. Go to https://github.com/aRustyDev/helm-charts/settings/variables/actions
2. Click "New repository variable"
3. Name: `X_REPO_AUTH_APP_ID`
4. Value: `2608951`

## After Merging
Future release-please PRs will be created by the GitHub App and will automatically trigger the lint-test workflow.

## Test Plan
- [ ] Secrets and variables configured
- [ ] Merge this PR
- [ ] Verify next release-please PR triggers workflows automatically

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)