### PR TITLE
feat(cloudflared): add Prometheus metrics support

### DIFF
--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -122,6 +122,51 @@ tunnelConfig:
 
 The chart will create an `ExternalSecret` resource that syncs your credentials from the external store to a Kubernetes Secret, which is then mounted by the cloudflared deployment.
 
+### Prometheus Metrics
+
+Cloudflared exposes Prometheus metrics on port 2000 by default. This chart provides several options for scraping these metrics.
+
+#### Using Prometheus Operator (Recommended)
+
+If you have Prometheus Operator installed, you can enable ServiceMonitor or PodMonitor resources:
+
+**For Deployment mode** (when `replica.allNodes: false`):
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    interval: "30s"
+    labels:
+      release: prometheus  # Match your Prometheus selector
+```
+
+**For DaemonSet mode** (when `replica.allNodes: true`):
+```yaml
+metrics:
+  enabled: true
+  podMonitor:
+    enabled: true
+    interval: "30s"
+    labels:
+      release: prometheus  # Match your Prometheus selector
+```
+
+#### Using Service Annotations
+
+For Prometheus setups using annotation-based service discovery:
+
+```yaml
+metrics:
+  enabled: true
+  service:
+    enabled: true
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "2000"
+      prometheus.io/path: "/metrics"
+```
+
 ### Configuring Ingress
 
 The default ingress configuration is shown below. Replace the placeholder values with your domain and server settings. It is recommended to use a separate `values.yaml` file to manage this configuration.

--- a/charts/cloudflared/templates/configmap.yaml
+++ b/charts/cloudflared/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
 
     ingress: {{ toYaml .Values.ingress | nindent 6 }}
 
-    metrics: 0.0.0.0:2000
+    metrics: 0.0.0.0:{{ .Values.metrics.port | default 2000 }}
     metrics-update-freq: {{ .Values.tunnelConfig.metricsUpdateFrequency }}
 
     autoupdate-freq: {{ .Values.tunnelConfig.autoUpdateFrequency }}

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -50,8 +50,8 @@ spec:
             - run
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: active-con-stat
-              containerPort: 2000
+            - name: metrics
+              containerPort: {{ .Values.metrics.port | default 2000 }}
               protocol: TCP
           env:
             - name: TUNNEL_ORIGIN_CERT
@@ -59,7 +59,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /ready
-              port: 2000
+              port: {{ .Values.metrics.port | default 2000 }}
             failureThreshold: 1
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/charts/cloudflared/templates/podmonitor.yaml
+++ b/charts/cloudflared/templates/podmonitor.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.metrics.enabled .Values.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "cloudflared.fullname" . }}
+  {{- if .Values.metrics.podMonitor.namespace }}
+  namespace: {{ .Values.metrics.podMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "cloudflared.labels" . | nindent 4 }}
+    {{- with .Values.metrics.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.metrics.podMonitor.namespace }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cloudflared.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: {{ .Values.metrics.path | default "/metrics" }}
+      {{- with .Values.metrics.podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- if .Values.metrics.podMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/cloudflared/templates/service.yaml
+++ b/charts/cloudflared/templates/service.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.metrics.enabled .Values.metrics.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudflared.fullname" . }}-metrics
+  labels:
+    {{- include "cloudflared.labels" . | nindent 4 }}
+    {{- with .Values.metrics.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  ports:
+    - port: {{ .Values.metrics.port | default 2000 }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "cloudflared.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/cloudflared/templates/servicemonitor.yaml
+++ b/charts/cloudflared/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cloudflared.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "cloudflared.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cloudflared.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: {{ .Values.metrics.path | default "/metrics" }}
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/cloudflared/values.schema.json
+++ b/charts/cloudflared/values.schema.json
@@ -9,6 +9,220 @@
       "title": "affinity",
       "type": "object"
     },
+    "metrics": {
+      "additionalProperties": false,
+      "description": "Prometheus metrics configuration. Cloudflared exposes metrics on port 2000 by default.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "Enable metrics endpoint",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "port": {
+          "default": 2000,
+          "description": "Metrics port (cloudflared default is 2000)",
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        },
+        "path": {
+          "default": "/metrics",
+          "description": "Metrics path",
+          "required": [],
+          "title": "path",
+          "type": "string"
+        },
+        "service": {
+          "additionalProperties": false,
+          "description": "Metrics service configuration",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "description": "Enable metrics service for scraping",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "type": {
+              "default": "ClusterIP",
+              "description": "Service type",
+              "required": [],
+              "title": "type",
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+            },
+            "labels": {
+              "additionalProperties": true,
+              "description": "Additional service labels",
+              "required": [],
+              "title": "labels",
+              "type": "object"
+            },
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Additional service annotations (e.g., prometheus.io/scrape)",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            }
+          },
+          "required": ["enabled"],
+          "title": "service",
+          "type": "object"
+        },
+        "serviceMonitor": {
+          "additionalProperties": false,
+          "description": "ServiceMonitor configuration for Prometheus Operator (use with Deployment mode)",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable ServiceMonitor creation",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "namespace": {
+              "default": "",
+              "description": "Namespace to create ServiceMonitor in (defaults to release namespace)",
+              "required": [],
+              "title": "namespace",
+              "type": "string"
+            },
+            "interval": {
+              "default": "30s",
+              "description": "Scrape interval",
+              "required": [],
+              "title": "interval",
+              "type": "string"
+            },
+            "scrapeTimeout": {
+              "default": "10s",
+              "description": "Scrape timeout",
+              "required": [],
+              "title": "scrapeTimeout",
+              "type": "string"
+            },
+            "labels": {
+              "additionalProperties": true,
+              "description": "Additional labels for ServiceMonitor",
+              "required": [],
+              "title": "labels",
+              "type": "object"
+            },
+            "honorLabels": {
+              "default": false,
+              "description": "Honor labels from the scraped target",
+              "required": [],
+              "title": "honorLabels",
+              "type": "boolean"
+            },
+            "metricRelabelings": {
+              "description": "Metric relabeling configs",
+              "items": {
+                "additionalProperties": true,
+                "required": [],
+                "type": "object"
+              },
+              "required": [],
+              "title": "metricRelabelings",
+              "type": "array"
+            },
+            "relabelings": {
+              "description": "Relabeling configs",
+              "items": {
+                "additionalProperties": true,
+                "required": [],
+                "type": "object"
+              },
+              "required": [],
+              "title": "relabelings",
+              "type": "array"
+            }
+          },
+          "required": ["enabled"],
+          "title": "serviceMonitor",
+          "type": "object"
+        },
+        "podMonitor": {
+          "additionalProperties": false,
+          "description": "PodMonitor configuration for Prometheus Operator (use with DaemonSet mode)",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable PodMonitor creation",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "namespace": {
+              "default": "",
+              "description": "Namespace to create PodMonitor in (defaults to release namespace)",
+              "required": [],
+              "title": "namespace",
+              "type": "string"
+            },
+            "interval": {
+              "default": "30s",
+              "description": "Scrape interval",
+              "required": [],
+              "title": "interval",
+              "type": "string"
+            },
+            "scrapeTimeout": {
+              "default": "10s",
+              "description": "Scrape timeout",
+              "required": [],
+              "title": "scrapeTimeout",
+              "type": "string"
+            },
+            "labels": {
+              "additionalProperties": true,
+              "description": "Additional labels for PodMonitor",
+              "required": [],
+              "title": "labels",
+              "type": "object"
+            },
+            "honorLabels": {
+              "default": false,
+              "description": "Honor labels from the scraped target",
+              "required": [],
+              "title": "honorLabels",
+              "type": "boolean"
+            },
+            "metricRelabelings": {
+              "description": "Metric relabeling configs",
+              "items": {
+                "additionalProperties": true,
+                "required": [],
+                "type": "object"
+              },
+              "required": [],
+              "title": "metricRelabelings",
+              "type": "array"
+            },
+            "relabelings": {
+              "description": "Relabeling configs",
+              "items": {
+                "additionalProperties": true,
+                "required": [],
+                "type": "object"
+              },
+              "required": [],
+              "title": "relabelings",
+              "type": "array"
+            }
+          },
+          "required": ["enabled"],
+          "title": "podMonitor",
+          "type": "object"
+        }
+      },
+      "required": ["enabled"],
+      "title": "metrics",
+      "type": "object"
+    },
     "fullnameOverride": {
       "default": "",
       "required": [],
@@ -811,7 +1025,8 @@
     "resources",
     "nodeSelector",
     "tolerations",
-    "affinity"
+    "affinity",
+    "metrics"
   ],
   "type": "object"
 }

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -164,3 +164,58 @@ tolerations:
 
 # -- For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
+
+# -- Prometheus metrics configuration. Cloudflared exposes metrics on port 2000 by default.
+metrics:
+  # -- Enable metrics endpoint
+  enabled: true
+  # -- Metrics port (cloudflared default is 2000)
+  port: 2000
+  # -- Metrics path
+  path: "/metrics"
+  # -- Metrics service configuration
+  service:
+    # -- Enable metrics service for scraping
+    enabled: true
+    # -- Service type
+    type: ClusterIP
+    # -- Additional service labels
+    labels: {}
+    # -- Additional service annotations (e.g., prometheus.io/scrape)
+    annotations: {}
+  # -- ServiceMonitor configuration for Prometheus Operator (use with Deployment mode)
+  serviceMonitor:
+    # -- Enable ServiceMonitor creation
+    enabled: false
+    # -- Namespace to create ServiceMonitor in (defaults to release namespace)
+    namespace: ""
+    # -- Scrape interval
+    interval: "30s"
+    # -- Scrape timeout
+    scrapeTimeout: "10s"
+    # -- Additional labels for ServiceMonitor
+    labels: {}
+    # -- Honor labels from the scraped target
+    honorLabels: false
+    # -- Metric relabeling configs
+    metricRelabelings: []
+    # -- Relabeling configs
+    relabelings: []
+  # -- PodMonitor configuration for Prometheus Operator (use with DaemonSet mode)
+  podMonitor:
+    # -- Enable PodMonitor creation
+    enabled: false
+    # -- Namespace to create PodMonitor in (defaults to release namespace)
+    namespace: ""
+    # -- Scrape interval
+    interval: "30s"
+    # -- Scrape timeout
+    scrapeTimeout: "10s"
+    # -- Additional labels for PodMonitor
+    labels: {}
+    # -- Honor labels from the scraped target
+    honorLabels: false
+    # -- Metric relabeling configs
+    metricRelabelings: []
+    # -- Relabeling configs
+    relabelings: []


### PR DESCRIPTION
## Summary
- Add metrics Service for scraping cloudflared metrics endpoint
- Add ServiceMonitor for Prometheus Operator (use with Deployment mode)
- Add PodMonitor for Prometheus Operator (use with DaemonSet mode)
- Make metrics port configurable via `metrics.port` (default: 2000)
- Rename container port from `active-con-stat` to `metrics` for clarity
- Add comprehensive metrics configuration to values.yaml and schema

## Features
- **Metrics Service**: Enabled by default, creates a ClusterIP service for scraping
- **ServiceMonitor**: For Prometheus Operator users running in Deployment mode
- **PodMonitor**: For Prometheus Operator users running in DaemonSet mode
- **Configurable port**: Change metrics port via `metrics.port` value
- **Service annotations**: Support for `prometheus.io/*` annotations for non-Operator setups
- **honorLabels**: Option to preserve labels from scraped targets
- **Relabeling**: Full support for metricRelabelings and relabelings

## Configuration Examples

### Prometheus Operator (DaemonSet mode - default)
```yaml
metrics:
  enabled: true
  podMonitor:
    enabled: true
    labels:
      release: prometheus
```

### Prometheus Operator (Deployment mode)
```yaml
replica:
  allNodes: false
metrics:
  enabled: true
  serviceMonitor:
    enabled: true
    labels:
      release: prometheus
```

### Annotation-based discovery
```yaml
metrics:
  service:
    annotations:
      prometheus.io/scrape: "true"
      prometheus.io/port: "2000"
```

## Test plan
- [x] `helm lint` passes
- [x] Service renders when `metrics.service.enabled=true`
- [x] ServiceMonitor renders when `metrics.serviceMonitor.enabled=true`
- [x] PodMonitor renders when `metrics.podMonitor.enabled=true`
- [x] Resources not rendered when disabled
- [x] Configurable port works in configmap, deployment, and service

🤖 Generated with [Claude Code](https://claude.ai/code)