### PR TITLE
feat(cloudflared): add Linkerd service mesh integration

### DIFF
--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -167,6 +167,51 @@ metrics:
       prometheus.io/path: "/metrics"
 ```
 
+### Linkerd Service Mesh
+
+This chart supports [Linkerd](https://linkerd.io/) service mesh integration for automatic mTLS between cloudflared and your origin services.
+
+#### Enabling Linkerd
+
+```yaml
+linkerd:
+  enabled: true
+```
+
+When enabled, the chart adds the `linkerd.io/inject: enabled` annotation to pods, triggering automatic sidecar injection.
+
+#### Skip Outbound Ports
+
+By default, ports 443 and 7844 are excluded from the Linkerd proxy:
+
+```yaml
+linkerd:
+  enabled: true
+  skipOutboundPorts: "443,7844"  # Default value
+```
+
+**Why skip these ports?**
+- **Port 443**: Used for HTTPS connections to Cloudflare's API
+- **Port 7844**: Used for QUIC tunnel traffic to Cloudflare's edge
+
+These connections already use TLS with Cloudflare's certificates. Proxying them through Linkerd would cause double-TLS overhead and potentially break certificate validation. QUIC traffic (UDP-based) cannot be proxied by Linkerd.
+
+#### Custom Proxy Configuration
+
+Fine-tune the Linkerd proxy with additional annotations:
+
+```yaml
+linkerd:
+  enabled: true
+  annotations:
+    config.linkerd.io/proxy-cpu-request: "100m"
+    config.linkerd.io/proxy-memory-request: "128Mi"
+    config.linkerd.io/proxy-cpu-limit: "1"
+    config.linkerd.io/proxy-memory-limit: "256Mi"
+```
+
+> **Note**: Linkerd must be installed in your cluster before enabling this feature. See [Linkerd Getting Started](https://linkerd.io/2/getting-started/) for installation instructions.
+
 ### Configuring Ingress
 
 The default ingress configuration is shown below. Replace the placeholder values with your domain and server settings. It is recommended to use a separate `values.yaml` file to manage this configuration.

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -24,6 +24,15 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if .Values.linkerd.enabled }}
+        linkerd.io/inject: enabled
+        {{- if .Values.linkerd.skipOutboundPorts }}
+        config.linkerd.io/skip-outbound-ports: {{ .Values.linkerd.skipOutboundPorts | quote }}
+        {{- end }}
+        {{- with .Values.linkerd.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/cloudflared/values.schema.json
+++ b/charts/cloudflared/values.schema.json
@@ -1003,6 +1003,36 @@
       "required": ["type"],
       "title": "updateStrategy",
       "type": "object"
+    },
+    "linkerd": {
+      "additionalProperties": false,
+      "description": "Linkerd service mesh integration. For more information checkout: https://linkerd.io/",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Enable Linkerd service mesh integration",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "skipOutboundPorts": {
+          "default": "443,7844",
+          "description": "Ports to skip from Linkerd proxy (Cloudflare edge uses 443 and 7844 for QUIC)",
+          "required": [],
+          "title": "skipOutboundPorts",
+          "type": "string"
+        },
+        "annotations": {
+          "additionalProperties": true,
+          "description": "Additional Linkerd annotations for fine-tuning proxy behavior",
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        }
+      },
+      "required": ["enabled"],
+      "title": "linkerd",
+      "type": "object"
     }
   },
   "required": [
@@ -1026,7 +1056,8 @@
     "nodeSelector",
     "tolerations",
     "affinity",
-    "metrics"
+    "metrics",
+    "linkerd"
   ],
   "type": "object"
 }

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -219,3 +219,18 @@ metrics:
     metricRelabelings: []
     # -- Relabeling configs
     relabelings: []
+
+# -- Linkerd service mesh integration. For more information checkout: https://linkerd.io/
+linkerd:
+  # -- Enable Linkerd service mesh integration
+  enabled: false
+  # -- Ports to skip from Linkerd proxy (Cloudflare edge uses 443 and 7844 for QUIC).
+  # These are excluded to avoid double-TLS and allow direct connection to Cloudflare.
+  skipOutboundPorts: "443,7844"
+  # -- Additional Linkerd annotations for fine-tuning proxy behavior
+  annotations: {}
+    # config.linkerd.io/proxy-cpu-request: "100m"
+    # config.linkerd.io/proxy-memory-request: "128Mi"
+    # config.linkerd.io/proxy-cpu-limit: "1"
+    # config.linkerd.io/proxy-memory-limit: "256Mi"
+    # config.linkerd.io/opaque-ports: "7844"


### PR DESCRIPTION
## Summary
- Add Linkerd service mesh support for automatic mTLS between cloudflared and origin services
- Add `linkerd.enabled` flag to enable automatic sidecar injection
- Add `linkerd.skipOutboundPorts` (default: `"443,7844"`) to exclude Cloudflare edge connections
- Add `linkerd.annotations` for custom proxy configuration

## Why Skip Outbound Ports?

Cloudflared connects to Cloudflare's edge on ports 443 and 7844. These are excluded from the Linkerd proxy because:

| Port | Purpose | Why Skip |
|------|---------|----------|
| 443 | HTTPS to Cloudflare API | Already TLS-encrypted, double-TLS causes overhead |
| 7844 | QUIC tunnel traffic | UDP-based, Linkerd cannot proxy UDP traffic |

## Configuration Examples

### Basic Linkerd Integration
```yaml
linkerd:
  enabled: true
```

### Custom Proxy Resources
```yaml
linkerd:
  enabled: true
  annotations:
    config.linkerd.io/proxy-cpu-request: "100m"
    config.linkerd.io/proxy-memory-request: "128Mi"
```

### Custom Skip Ports
```yaml
linkerd:
  enabled: true
  skipOutboundPorts: "443,7844,8443"  # Add additional ports
```

## Test Plan
- [x] `helm lint` passes
- [x] Linkerd annotations render when `linkerd.enabled=true`
- [x] `skip-outbound-ports` renders with correct value
- [x] No Linkerd annotations when `linkerd.enabled=false`
- [x] Custom annotations merge correctly
- [x] Schema validates `skipOutboundPorts` as string type

## Note
This PR will be used as a testbed for investigating the release-please "Resource not accessible by integration" issue (#42).

🤖 Generated with [Claude Code](https://claude.ai/code)