### PR TITLE
feat(ci): add W8 atomic release publishing workflow

### DIFF
--- a/.claude/plans/chart-release-workflows/workflow-8/plan.md
+++ b/.claude/plans/chart-release-workflows/workflow-8/plan.md
@@ -22,17 +22,27 @@ Load these skills before planning, research, or implementation:
 ## Prerequisites
 
 ### Shared Components Required (Build First)
-- [ ] `detect_changed_charts` shell function
-- [ ] `extract_attestation_map` shell function
+- [x] `detect_changed_charts` shell function (implemented in attestation-lib.sh)
+- [x] `extract_attestation_map` shell function (implemented in attestation-lib.sh)
+- [x] `get_source_pr` shell function (implemented in attestation-lib.sh)
+- [x] `extract_changelog_for_version` shell function (implemented in attestation-lib.sh)
 
 ### Infrastructure Required
-- [ ] `release-protection` ruleset configured
-- [ ] GHCR access configured
-- [ ] Cosign keyless signing enabled
+- [x] `release-branch-protection` ruleset configured (ID: 11884271)
+- [x] GHCR access configured (standard with `packages: write` permission)
+- [x] Cosign keyless signing enabled (standard with `id-token: write` permission)
+- [x] GitHub App for pushing to protected release branch (via 1Password)
 
 ### Upstream Dependencies
-- [ ] Workflow 7 must have merged the PR (triggers this workflow)
-- [ ] Tags must exist for charts being released
+- [x] Workflow 7 validates and builds chart packages (triggers this workflow on merge)
+- [x] Tags exist for charts being released (created by W6)
+
+### Key Assumptions
+- **Single chart per merge**: Each release PR contains exactly ONE chart (enforced by W6/W7)
+- **Three distribution channels**:
+  1. **GHCR (OCI)**: `helm pull oci://ghcr.io/<owner>/charts/<chart>`
+  2. **GitHub Releases**: Assets for direct download
+  3. **index.yaml**: Updated on release branch for `helm repo add`
 
 ---
 
@@ -84,36 +94,112 @@ Load these skills before planning, research, or implementation:
 
 ### Phase 8.3: Chart Detection
 **Effort**: Low
-**Dependencies**: Phase 8.1, `detect_changed_charts`
+**Dependencies**: Phase 8.1, `get_source_pr`
+
+**Note**: Each merge contains exactly ONE chart (enforced by W6/W7). Extract chart info from the merge commit message.
 
 **Tasks**:
-1. Detect charts changed in this merge
-2. Get version for each chart
-3. Construct tag names
+1. Extract chart name and version from merge commit message (format: `release: <chart>-v<version>`)
+2. Validate chart exists in `charts/` directory
+3. Construct tag name
+
+**Code**:
+```bash
+# Get merge commit message
+COMMIT_MSG=$(git log -1 --format="%s" HEAD)
+
+# Extract from "Merge pull request #X from ... release: <chart>-v<version>"
+# Or direct merge commit "release: <chart>-v<version>"
+if [[ "$COMMIT_MSG" =~ release:\ ([a-z0-9-]+)-v([0-9]+\.[0-9]+\.[0-9]+.*) ]]; then
+  CHART="${BASH_REMATCH[1]}"
+  VERSION="${BASH_REMATCH[2]}"
+elif [[ "$COMMIT_MSG" =~ Merge\ pull\ request ]]; then
+  # Fallback: detect from changed files
+  CHART=$(git diff --name-only HEAD~1..HEAD | grep '^charts/' | cut -d'/' -f2 | sort -u | head -1)
+  VERSION=$(grep '^version:' "charts/$CHART/Chart.yaml" | awk '{print $2}' | tr -d '"' | tr -d "'")
+fi
+
+TAG="${CHART}-v${VERSION}"
+
+# Validate
+if [[ ! -d "charts/$CHART" ]]; then
+  echo "::error::Chart directory not found: charts/$CHART"
+  exit 1
+fi
+
+echo "chart=$CHART" >> "$GITHUB_OUTPUT"
+echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+```
 
 ---
 
 ### Phase 8.4: Attestation Lineage Retrieval
 **Effort**: Medium
-**Dependencies**: Phase 8.3, `extract_attestation_map`
+**Dependencies**: Phase 8.3, `extract_attestation_map`, `get_source_pr`
+
+**Note**: Single chart - extract attestation map from the merged PR or tag annotation.
 
 **Tasks**:
-1. Find the PR that was merged
-2. Extract full attestation map
-3. Store for release assets
+1. Find the PR that was merged (from merge commit)
+2. Extract attestation map from PR description (W7 added it)
+3. Also extract from tag annotation (W6 added it)
+4. Store combined lineage for release assets
+
+**Code**:
+```bash
+source .github/scripts/attestation-lib.sh
+
+TAG="${{ steps.detect-chart.outputs.tag }}"
+
+# Get PR number from merge commit
+PR_NUMBER=$(get_source_pr HEAD)
+
+ATTESTATION_MAP="{}"
+if [[ -n "$PR_NUMBER" ]]; then
+  # Extract from PR description (includes W7 build attestation)
+  ATTESTATION_MAP=$(extract_attestation_map "$PR_NUMBER")
+fi
+
+# Also get attestation lineage from tag annotation (upstream attestations from W5)
+TAG_ANNOTATION=$(git tag -l --format='%(contents)' "$TAG")
+TAG_ATTESTATIONS=$(echo "$TAG_ANNOTATION" | sed -n '/^Attestation Lineage:/,/^$/p' | grep '^- ' || true)
+
+echo "attestation_map=$ATTESTATION_MAP" >> "$GITHUB_OUTPUT"
+echo "tag_attestations<<EOF" >> "$GITHUB_OUTPUT"
+echo "$TAG_ATTESTATIONS" >> "$GITHUB_OUTPUT"
+echo "EOF" >> "$GITHUB_OUTPUT"
+```
 
 ---
 
-### Phase 8.5: Build Chart Packages
+### Phase 8.5: Build Chart Package
 **Effort**: Low
 **Dependencies**: Phase 8.3
 
-**Tasks**:
-1. Build/rebuild chart packages
-2. Calculate digests
-3. Store in temporary directory
+**Note**: Single chart - rebuild package for consistency (simpler than downloading W7 artifacts).
 
-**Note**: May use artifacts from W7 or rebuild for consistency
+**Tasks**:
+1. Build chart package with `helm package`
+2. Calculate SHA256 digest
+3. Store in `.cr-release-packages/`
+
+**Code**:
+```bash
+CHART="${{ steps.detect-chart.outputs.chart }}"
+VERSION="${{ steps.detect-chart.outputs.version }}"
+
+mkdir -p .cr-release-packages
+
+helm package "charts/$CHART" -d .cr-release-packages/
+
+PACKAGE_FILE=".cr-release-packages/${CHART}-${VERSION}.tgz"
+DIGEST=$(sha256sum "$PACKAGE_FILE" | cut -d' ' -f1)
+
+echo "package=$PACKAGE_FILE" >> "$GITHUB_OUTPUT"
+echo "digest=sha256:$DIGEST" >> "$GITHUB_OUTPUT"
+echo "package_name=${CHART}-${VERSION}.tgz" >> "$GITHUB_OUTPUT"
+```
 
 ---
 
@@ -121,135 +207,283 @@ Load these skills before planning, research, or implementation:
 **Effort**: High
 **Dependencies**: Phase 8.2, Phase 8.5
 
+**Note**: Single chart - push to GHCR OCI registry and sign with Cosign keyless.
+
 **Tasks**:
-1. For each chart:
-   - Run `helm push` to GHCR OCI registry
-   - Capture digest from output
-   - Sign package with Cosign (keyless)
-2. Handle push failures with retry
+1. Push chart package to GHCR OCI registry
+2. Capture digest from push output
+3. Sign package with Cosign (keyless)
+4. Handle push failures with retry (3 attempts)
 
 **Code**:
 ```bash
-REGISTRY="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/charts"
+CHART="${{ steps.detect-chart.outputs.chart }}"
+VERSION="${{ steps.detect-chart.outputs.version }}"
+PACKAGE="${{ steps.build-package.outputs.package }}"
+REGISTRY="ghcr.io/${{ github.repository_owner }}/charts"
 
-for chart in $CHARTS; do
-  VERSION=$(grep '^version:' "charts/$chart/Chart.yaml" | awk '{print $2}')
-  TGZ=".cr-release-packages/${chart}-${VERSION}.tgz"
+# Convert to lowercase (GHCR requirement)
+REGISTRY="${REGISTRY,,}"
 
-  # Push to GHCR
-  PUSH_OUTPUT=$(helm push "$TGZ" oci://$REGISTRY 2>&1)
-  DIGEST=$(echo "$PUSH_OUTPUT" | grep -oP 'Digest: \Ksha256:[a-f0-9]+')
+MAX_RETRIES=3
+RETRY_DELAY=5
 
-  # Sign by digest
-  cosign sign --yes "$REGISTRY/${chart}@${DIGEST}"
+for ((attempt=1; attempt<=MAX_RETRIES; attempt++)); do
+  echo "::group::Pushing to GHCR (attempt $attempt/$MAX_RETRIES)"
+
+  if PUSH_OUTPUT=$(helm push "$PACKAGE" "oci://$REGISTRY" 2>&1); then
+    echo "$PUSH_OUTPUT"
+    OCI_DIGEST=$(echo "$PUSH_OUTPUT" | grep -oP 'Digest: \Ksha256:[a-f0-9]+' || true)
+
+    if [[ -n "$OCI_DIGEST" ]]; then
+      echo "::notice::Pushed $CHART:$VERSION to GHCR"
+      echo "::notice::OCI Digest: $OCI_DIGEST"
+      break
+    fi
+  fi
+
+  echo "::warning::Push attempt $attempt failed"
+  echo "$PUSH_OUTPUT"
+
+  if [[ $attempt -lt $MAX_RETRIES ]]; then
+    echo "Retrying in ${RETRY_DELAY}s..."
+    sleep $RETRY_DELAY
+    RETRY_DELAY=$((RETRY_DELAY * 2))
+  else
+    echo "::error::Failed to push to GHCR after $MAX_RETRIES attempts"
+    exit 1
+  fi
+  echo "::endgroup::"
 done
+
+# Sign with Cosign (keyless via OIDC)
+echo "::group::Signing with Cosign"
+cosign sign --yes "$REGISTRY/$CHART@$OCI_DIGEST"
+echo "::notice::Signed $CHART@$OCI_DIGEST"
+echo "::endgroup::"
+
+echo "oci_digest=$OCI_DIGEST" >> "$GITHUB_OUTPUT"
+echo "oci_url=$REGISTRY/$CHART:$VERSION" >> "$GITHUB_OUTPUT"
 ```
 
-**Questions**:
-- [ ] How to verify push succeeded?
-- [ ] Retry strategy for transient failures?
-- [ ] How to handle existing versions in registry?
+**Resolved Questions**:
+- ✅ **Verify push succeeded**: Check exit code and presence of digest in output
+- ✅ **Retry strategy**: 3 retries with exponential backoff (5s, 10s, 20s)
+- ✅ **Existing versions**: `helm push` fails if version exists - this is correct (immutable versions)
 
 ---
 
-### Phase 8.7: Create GitHub Releases
+### Phase 8.7: Create GitHub Release
 **Effort**: High
 **Dependencies**: Phase 8.4, Phase 8.5, Phase 8.6
 
+**Note**: Single chart - create one release with all assets.
+
 **Tasks**:
-1. For each chart:
-   - Check if release exists (by tag)
-   - If not, create release
-   - Upload assets:
-     - Chart package (.tgz)
-     - Package signature (.tgz.sig)
-     - Attestation lineage JSON
-     - CHANGELOG.md
-     - README.md
-     - LICENSE
+1. Check if release exists (by tag) - skip if already exists (idempotent)
+2. Sign package blob for file signature (.tgz.sig)
+3. Create attestation lineage JSON file
+4. Create GitHub Release with assets:
+   - Chart package (.tgz)
+   - Package signature (.tgz.sig)
+   - Attestation lineage JSON
+   - CHANGELOG.md (if exists)
+   - README.md (if exists)
 
 **Code**:
 ```bash
-for chart in $CHARTS; do
-  VERSION=$(grep '^version:' "charts/$chart/Chart.yaml" | awk '{print $2}')
-  TAG="${chart}-v${VERSION}"
-  TGZ=".cr-release-packages/${chart}-${VERSION}.tgz"
+CHART="${{ steps.detect-chart.outputs.chart }}"
+VERSION="${{ steps.detect-chart.outputs.version }}"
+TAG="${{ steps.detect-chart.outputs.tag }}"
+PACKAGE="${{ steps.build-package.outputs.package }}"
+DIGEST="${{ steps.build-package.outputs.digest }}"
+OCI_DIGEST="${{ steps.publish-ghcr.outputs.oci_digest }}"
+ATTESTATION_MAP='${{ steps.attestation-lineage.outputs.attestation_map }}'
 
-  # Sign blob for file signature
-  cosign sign-blob --yes --output-signature "${TGZ}.sig" "$TGZ"
+# Check if release already exists
+if gh release view "$TAG" >/dev/null 2>&1; then
+  echo "::notice::Release $TAG already exists, skipping creation"
+  echo "release_url=$(gh release view "$TAG" --json url -q '.url')" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
 
-  # Create attestation lineage file
-  cat > "${chart}-attestation-lineage.json" <<EOF
-  {
-    "chart": "$chart",
-    "version": "$VERSION",
-    "tag": "$TAG",
-    "digest": "$DIGEST",
-    "attestations": $ATTESTATION_MAP
-  }
-  EOF
+# Sign package blob
+echo "::group::Signing package blob"
+cosign sign-blob --yes --output-signature "${PACKAGE}.sig" "$PACKAGE"
+echo "::endgroup::"
 
-  # Create release
-  gh release create "$TAG" \
-    --title "$chart: v$VERSION" \
-    --notes "$(generate_release_notes)" \
-    "$TGZ" \
-    "${TGZ}.sig" \
-    "${chart}-attestation-lineage.json" \
-    "charts/$chart/CHANGELOG.md" \
-    "charts/$chart/README.md" \
-    "charts/$chart/LICENSE"
-done
+# Create attestation lineage file
+cat > "${CHART}-attestation-lineage.json" <<EOF
+{
+  "chart": "$CHART",
+  "version": "$VERSION",
+  "tag": "$TAG",
+  "package_digest": "$DIGEST",
+  "oci_digest": "$OCI_DIGEST",
+  "attestations": $ATTESTATION_MAP,
+  "published_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+# Collect assets
+ASSETS=("$PACKAGE" "${PACKAGE}.sig" "${CHART}-attestation-lineage.json")
+
+# Add optional assets if they exist
+[[ -f "charts/$CHART/CHANGELOG.md" ]] && ASSETS+=("charts/$CHART/CHANGELOG.md")
+[[ -f "charts/$CHART/README.md" ]] && ASSETS+=("charts/$CHART/README.md")
+
+# Generate release notes
+RELEASE_NOTES=$(generate_release_notes "$CHART" "$VERSION" "$TAG" "$OCI_DIGEST")
+
+# Create release
+gh release create "$TAG" \
+  --title "$CHART v$VERSION" \
+  --notes "$RELEASE_NOTES" \
+  "${ASSETS[@]}"
+
+echo "::notice::Created release: $TAG"
+echo "release_url=$(gh release view "$TAG" --json url -q '.url')" >> "$GITHUB_OUTPUT"
 ```
 
 ---
 
 ### Phase 8.8: Generate Release Notes
 **Effort**: Medium
-**Dependencies**: Phase 8.4
+**Dependencies**: Phase 8.4, `extract_changelog_for_version`
+
+**Note**: Generate comprehensive release notes with installation and verification instructions.
 
 **Tasks**:
-1. Extract changelog from tag annotation or file
-2. Include attestation verification commands
-3. Include installation instructions
+1. Extract changelog from chart's CHANGELOG.md
+2. Include attestation lineage summary
+3. Include installation instructions (GHCR OCI + helm repo)
+4. Include verification commands (Cosign + gh attestation)
 
-**Release Notes Template**:
-```markdown
-## <chart> v<version>
+**Code**:
+```bash
+generate_release_notes() {
+  local chart="$1"
+  local version="$2"
+  local tag="$3"
+  local oci_digest="$4"
+
+  source .github/scripts/attestation-lib.sh
+
+  # Get changelog
+  local changelog
+  changelog=$(extract_changelog_for_version "$chart" "$version")
+
+  cat <<EOF
+## $chart v$version
 
 ### Changelog
-<changelog content>
 
-### Attestation Lineage
-<attestation IDs>
+$changelog
 
 ### Installation
 
-```bash
-# From GHCR (OCI)
-helm install <chart> oci://ghcr.io/<owner>/charts/<chart> --version <version>
+\`\`\`bash
+# Option 1: From GHCR (OCI) - Recommended
+helm install $chart oci://ghcr.io/${{ github.repository_owner }}/charts/$chart --version $version
 
-# Verify signature
-cosign verify ghcr.io/<owner>/charts/<chart>:<version>
-```
+# Option 2: From Helm Repository
+helm repo add arustydev https://charts.arusty.dev
+helm repo update
+helm install $chart arustydev/$chart --version $version
+\`\`\`
 
 ### Verification
-```bash
+
+\`\`\`bash
+# Verify OCI signature with Cosign
+cosign verify ghcr.io/${{ github.repository_owner }}/charts/$chart@$oci_digest
+
 # Verify attestations
-gh attestation verify ghcr.io/<owner>/charts/<chart>@<digest>
-```
+gh attestation verify oci://ghcr.io/${{ github.repository_owner }}/charts/$chart:$version --repo ${{ github.repository }}
+\`\`\`
+
+### Attestation Lineage
+
+See \`$chart-attestation-lineage.json\` in release assets for full attestation chain.
+
+---
+*Released by W8: Atomic Release Publishing*
+EOF
+}
 ```
 
 ---
 
-### Phase 8.9: Summary Generation
+### Phase 8.9: Update Helm Repository Index
+**Effort**: Medium
+**Dependencies**: Phase 8.7
+
+**Note**: This is CRITICAL for GitHub Pages distribution via charts.arusty.dev.
+
+**Tasks**:
+1. Checkout release branch
+2. Copy package to release branch root (or use GitHub Releases URL)
+3. Update index.yaml with `helm repo index`
+4. Commit and push to release branch (requires GitHub App token)
+
+**Code**:
+```bash
+CHART="${{ steps.detect-chart.outputs.chart }}"
+VERSION="${{ steps.detect-chart.outputs.version }}"
+TAG="${{ steps.detect-chart.outputs.tag }}"
+PACKAGE="${{ steps.build-package.outputs.package }}"
+PACKAGE_NAME="${{ steps.build-package.outputs.package_name }}"
+
+# Configure git with App token for push
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+# Fetch release branch
+git fetch origin release
+
+# Create temporary worktree for release branch
+git worktree add ../release-branch origin/release
+
+cd ../release-branch
+
+# Copy package (or we can rely on GitHub Releases URL)
+# The index.yaml already points to GitHub Releases URLs, so we just need to update the index
+
+# Update index.yaml using helm repo index
+# --url points to GitHub Releases download URL
+# --merge merges with existing index
+helm repo index . \
+  --url "https://github.com/${{ github.repository }}/releases/download" \
+  --merge index.yaml
+
+# Commit and push
+git add index.yaml
+git commit -m "chore(release): update index.yaml for $CHART v$VERSION
+
+Tag: $TAG
+Release: https://github.com/${{ github.repository }}/releases/tag/$TAG"
+
+git push origin HEAD:release
+
+# Cleanup worktree
+cd ..
+git worktree remove release-branch
+
+echo "::notice::Updated index.yaml on release branch"
+```
+
+**Important**: This requires the GitHub App token to push to the protected release branch.
+
+---
+
+### Phase 8.10: Summary Generation
 **Effort**: Low
 **Dependencies**: All previous phases
 
 **Tasks**:
 1. Generate GitHub Step Summary
-2. Include table of released charts
-3. Include links to GHCR and releases
+2. Include chart details and links
+3. Include GHCR URL and GitHub Release URL
 4. Include verification commands
 
 ---
@@ -270,10 +504,10 @@ gh attestation verify ghcr.io/<owner>/charts/<chart>@<digest>
 
 ```
 ┌──────────────────────┐
-│ Workflow 7 merges    │
-│ PR to release        │
+│ W7 merges PR to      │
+│ release branch       │
 └──────────┬───────────┘
-           │
+           │ (triggers push event)
            ▼
 ┌──────────────────────┐
 │ Phase 8.1: Base      │
@@ -286,30 +520,42 @@ gh attestation verify ghcr.io/<owner>/charts/<chart>@<digest>
 │ (Helm, Cosign, GHCR) │
 └──────────┬───────────┘
            │
-     ┌─────┼─────┐
-     ▼     ▼     ▼
-┌──────┐ ┌──────┐ ┌──────────┐
-│8.3   │ │8.4   │ │8.5       │
-│Chart │ │Attest│ │Build     │
-│Detect│ │Lineage│ │Packages  │
-└──┬───┘ └──┬───┘ └────┬─────┘
-   │        │          │
-   └────────┼──────────┘
+           ▼
+┌──────────────────────┐
+│ Phase 8.3: Chart     │
+│ Detection (single)   │
+└──────────┬───────────┘
+           │
+     ┌─────┴─────┐
+     ▼           ▼
+┌──────────┐ ┌──────────┐
+│ 8.4      │ │ 8.5      │
+│ Attest   │ │ Build    │
+│ Lineage  │ │ Package  │
+└────┬─────┘ └────┬─────┘
+     │            │
+     └──────┬─────┘
             ▼
 ┌──────────────────────┐
 │ Phase 8.6: Publish   │
-│ to GHCR              │
+│ to GHCR + Cosign     │
 └──────────┬───────────┘
            │
            ▼
 ┌──────────────────────┐
 │ Phase 8.7: Create    │
-│ GitHub Releases      │
+│ GitHub Release       │
 └──────────┬───────────┘
            │
            ▼
 ┌──────────────────────┐
-│ Phase 8.9: Summary   │
+│ Phase 8.9: Update    │
+│ index.yaml           │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ Phase 8.10: Summary  │
 └──────────────────────┘
 ```
 
@@ -317,12 +563,28 @@ gh attestation verify ghcr.io/<owner>/charts/<chart>@<digest>
 
 ## Open Questions
 
-1. **GHCR Overwrite**: What if version already exists in GHCR?
-2. **Release Exists**: Update existing release or fail?
-3. **Missing Assets**: What if CHANGELOG or README missing?
-4. **Retry Strategy**: How many retries for GHCR push?
-5. **Cosign Keyless**: Any additional configuration needed?
-6. **Package Source**: Rebuild or use W7 artifacts?
+1. ✅ **GHCR Overwrite**: What if version already exists in GHCR?
+   - **Resolved**: `helm push` fails if version exists - this is correct behavior (immutable versions)
+   - If this happens, it indicates a workflow error (version should only be published once)
+
+2. ✅ **Release Exists**: Update existing release or fail?
+   - **Resolved**: Skip creation if release exists (idempotent behavior)
+   - Log notice and output existing release URL
+
+3. ✅ **Missing Assets**: What if CHANGELOG or README missing?
+   - **Resolved**: These are optional - only include if they exist
+   - Core assets (package, signature, attestation JSON) are always included
+
+4. ✅ **Retry Strategy**: How many retries for GHCR push?
+   - **Resolved**: 3 retries with exponential backoff (5s, 10s, 20s)
+
+5. ✅ **Cosign Keyless**: Any additional configuration needed?
+   - **Resolved**: Works out of the box with `id-token: write` permission
+   - Uses GitHub Actions OIDC for keyless signing
+
+6. ✅ **Package Source**: Rebuild or use W7 artifacts?
+   - **Resolved**: Rebuild in W8 for simplicity and reliability
+   - W7 artifacts have 30-day retention and may not be available
 
 ---
 
@@ -330,21 +592,30 @@ gh attestation verify ghcr.io/<owner>/charts/<chart>@<digest>
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| GHCR push fails | High | Retry logic, clear errors |
-| Cosign signing fails | High | Fallback to unsigned warning |
-| Release creation fails | Medium | Check for existing first |
-| Large package size | Low | Monitor package sizes |
-| Network timeouts | Medium | Longer timeouts, retry |
+| GHCR push fails | High | 3 retries with exponential backoff |
+| Cosign signing fails | High | Workflow fails - signing is required |
+| Release creation fails | Medium | Check for existing first (idempotent) |
+| index.yaml push fails | High | GitHub App token for protected branch |
+| Version already in GHCR | Medium | Expected failure - indicates duplicate release attempt |
+| Network timeouts | Medium | Retry logic, reasonable timeouts |
 
 ---
 
 ## Success Criteria
 
-- [ ] Workflow triggers on merge to release
-- [ ] Charts are pushed to GHCR successfully
-- [ ] Charts are signed with Cosign
-- [ ] GitHub Releases are created with all assets
-- [ ] Release notes include changelog and installation instructions
-- [ ] Attestation lineage JSON is included in release
-- [ ] Summary shows all released charts
-- [ ] Workflow completes in < 15 minutes
+- [ ] Workflow triggers on push to release branch (merge from main)
+- [ ] Detects single chart from merge commit
+- [ ] Retrieves attestation lineage from merged PR and tag
+- [ ] Builds chart package successfully
+- [ ] Pushes to GHCR OCI registry
+- [ ] Signs OCI artifact with Cosign (keyless)
+- [ ] Creates GitHub Release with assets:
+  - [ ] Chart package (.tgz)
+  - [ ] Package signature (.tgz.sig)
+  - [ ] Attestation lineage JSON
+  - [ ] CHANGELOG.md (if exists)
+  - [ ] README.md (if exists)
+- [ ] Release notes include installation and verification instructions
+- [ ] Updates index.yaml on release branch
+- [ ] Summary shows chart details and links
+- [ ] Workflow completes in < 10 minutes (single chart)

--- a/.github/workflows/atomic-release-publishing.yaml
+++ b/.github/workflows/atomic-release-publishing.yaml
@@ -1,0 +1,431 @@
+name: W8 - Atomic Release Publishing
+
+on:
+  push:
+    branches:
+      - release
+    paths:
+      - 'charts/**'
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: w8-publish-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    outputs:
+      chart: ${{ steps.detect-chart.outputs.chart }}
+      version: ${{ steps.detect-chart.outputs.version }}
+      tag: ${{ steps.detect-chart.outputs.tag }}
+      oci_url: ${{ steps.publish-ghcr.outputs.oci_url }}
+      release_url: ${{ steps.create-release.outputs.release_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for tags and diff
+
+      - name: Load secrets from 1Password
+        id: op-secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
+          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
+
+      # Phase 8.2: Setup
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'latest'
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Phase 8.3: Chart Detection
+      - name: Detect Chart
+        id: detect-chart
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          # Get merge commit message
+          COMMIT_MSG=$(git log -1 --format="%s" HEAD)
+          echo "::debug::Commit message: $COMMIT_MSG"
+
+          # Try to extract from PR title in merge commit
+          # Format: "Merge pull request #X from ... " followed by PR title
+          # Or squash merge: "release: <chart>-v<version> (#X)"
+          if [[ "$COMMIT_MSG" =~ release:\ ([a-z0-9-]+)-v([0-9]+\.[0-9]+\.[0-9]+[^\ ]*) ]]; then
+            CHART="${BASH_REMATCH[1]}"
+            VERSION="${BASH_REMATCH[2]}"
+            echo "::notice::Extracted from commit message: $CHART v$VERSION"
+          else
+            # Fallback: detect from changed files
+            echo "::notice::Falling back to file detection"
+            CHART=$(git diff --name-only HEAD~1..HEAD | grep '^charts/' | cut -d'/' -f2 | sort -u | head -1)
+
+            if [[ -z "$CHART" ]]; then
+              echo "::error::Could not detect chart from commit"
+              exit 1
+            fi
+
+            VERSION=$(grep '^version:' "charts/$CHART/Chart.yaml" | awk '{print $2}' | tr -d '"' | tr -d "'")
+            echo "::notice::Detected from files: $CHART v$VERSION"
+          fi
+
+          TAG="${CHART}-v${VERSION}"
+
+          # Validate chart directory exists
+          if [[ ! -d "charts/$CHART" ]]; then
+            echo "::error::Chart directory not found: charts/$CHART"
+            exit 1
+          fi
+
+          # Validate tag exists
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG does not exist"
+            echo "::error::W6 should have created this tag"
+            exit 1
+          fi
+
+          echo "::notice::Chart: $CHART, Version: $VERSION, Tag: $TAG"
+
+          echo "chart=$CHART" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      # Phase 8.4: Attestation Lineage Retrieval
+      - name: Get Attestation Lineage
+        id: attestation-lineage
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          TAG="${{ steps.detect-chart.outputs.tag }}"
+
+          # Get PR number from merge commit
+          PR_NUMBER=$(get_source_pr HEAD)
+          echo "::notice::Source PR: ${PR_NUMBER:-not found}"
+
+          ATTESTATION_MAP="{}"
+          if [[ -n "$PR_NUMBER" ]]; then
+            # Extract from PR description (includes W7 build attestation)
+            ATTESTATION_MAP=$(extract_attestation_map "$PR_NUMBER") || ATTESTATION_MAP="{}"
+          fi
+
+          # Also get attestation lineage from tag annotation
+          TAG_ANNOTATION=$(git tag -l --format='%(contents)' "$TAG")
+          TAG_ATTESTATIONS=$(echo "$TAG_ANNOTATION" | sed -n '/^Attestation Lineage:/,/^$/p' | grep '^- ' || true)
+
+          echo "::group::Attestation Lineage"
+          echo "PR Attestation Map: $ATTESTATION_MAP"
+          echo "Tag Attestations:"
+          echo "$TAG_ATTESTATIONS"
+          echo "::endgroup::"
+
+          echo "attestation_map=$ATTESTATION_MAP" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      # Phase 8.5: Build Chart Package
+      - name: Build Chart Package
+        id: build-package
+        run: |
+          CHART="${{ steps.detect-chart.outputs.chart }}"
+          VERSION="${{ steps.detect-chart.outputs.version }}"
+
+          mkdir -p .cr-release-packages
+
+          echo "::group::Building chart package"
+          helm package "charts/$CHART" -d .cr-release-packages/
+          echo "::endgroup::"
+
+          PACKAGE_FILE=".cr-release-packages/${CHART}-${VERSION}.tgz"
+
+          if [[ ! -f "$PACKAGE_FILE" ]]; then
+            echo "::error::Package file not created: $PACKAGE_FILE"
+            exit 1
+          fi
+
+          DIGEST=$(sha256sum "$PACKAGE_FILE" | cut -d' ' -f1)
+
+          echo "::notice::Package: $PACKAGE_FILE"
+          echo "::notice::Digest: sha256:$DIGEST"
+
+          echo "package=$PACKAGE_FILE" >> "$GITHUB_OUTPUT"
+          echo "digest=sha256:$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "package_name=${CHART}-${VERSION}.tgz" >> "$GITHUB_OUTPUT"
+
+      # Phase 8.6: Publish to GHCR
+      - name: Publish to GHCR
+        id: publish-ghcr
+        run: |
+          CHART="${{ steps.detect-chart.outputs.chart }}"
+          VERSION="${{ steps.detect-chart.outputs.version }}"
+          PACKAGE="${{ steps.build-package.outputs.package }}"
+
+          # GHCR requires lowercase
+          REGISTRY="ghcr.io/${{ github.repository_owner }}/charts"
+          REGISTRY="${REGISTRY,,}"
+
+          MAX_RETRIES=3
+          RETRY_DELAY=5
+          OCI_DIGEST=""
+
+          for ((attempt=1; attempt<=MAX_RETRIES; attempt++)); do
+            echo "::group::Pushing to GHCR (attempt $attempt/$MAX_RETRIES)"
+
+            if PUSH_OUTPUT=$(helm push "$PACKAGE" "oci://$REGISTRY" 2>&1); then
+              echo "$PUSH_OUTPUT"
+              OCI_DIGEST=$(echo "$PUSH_OUTPUT" | grep -oP 'Digest: \Ksha256:[a-f0-9]+' || true)
+
+              if [[ -n "$OCI_DIGEST" ]]; then
+                echo "::notice::Pushed $CHART:$VERSION to GHCR"
+                echo "::notice::OCI Digest: $OCI_DIGEST"
+                echo "::endgroup::"
+                break
+              fi
+            fi
+
+            echo "::warning::Push attempt $attempt failed"
+            echo "$PUSH_OUTPUT"
+            echo "::endgroup::"
+
+            if [[ $attempt -lt $MAX_RETRIES ]]; then
+              echo "Retrying in ${RETRY_DELAY}s..."
+              sleep $RETRY_DELAY
+              RETRY_DELAY=$((RETRY_DELAY * 2))
+            else
+              echo "::error::Failed to push to GHCR after $MAX_RETRIES attempts"
+              exit 1
+            fi
+          done
+
+          # Sign with Cosign (keyless via OIDC)
+          echo "::group::Signing with Cosign"
+          cosign sign --yes "$REGISTRY/$CHART@$OCI_DIGEST"
+          echo "::notice::Signed $CHART@$OCI_DIGEST"
+          echo "::endgroup::"
+
+          echo "oci_digest=$OCI_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "oci_url=$REGISTRY/$CHART:$VERSION" >> "$GITHUB_OUTPUT"
+          echo "oci_registry=$REGISTRY" >> "$GITHUB_OUTPUT"
+
+      # Phase 8.7: Create GitHub Release
+      - name: Create GitHub Release
+        id: create-release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          CHART="${{ steps.detect-chart.outputs.chart }}"
+          VERSION="${{ steps.detect-chart.outputs.version }}"
+          TAG="${{ steps.detect-chart.outputs.tag }}"
+          PACKAGE="${{ steps.build-package.outputs.package }}"
+          DIGEST="${{ steps.build-package.outputs.digest }}"
+          OCI_DIGEST="${{ steps.publish-ghcr.outputs.oci_digest }}"
+          OCI_REGISTRY="${{ steps.publish-ghcr.outputs.oci_registry }}"
+          ATTESTATION_MAP='${{ steps.attestation-lineage.outputs.attestation_map }}'
+
+          # Check if release already exists
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::Release $TAG already exists, skipping creation"
+            RELEASE_URL=$(gh release view "$TAG" --json url -q '.url')
+            echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
+            echo "release_exists=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Sign package blob
+          echo "::group::Signing package blob"
+          cosign sign-blob --yes --output-signature "${PACKAGE}.sig" "$PACKAGE"
+          echo "::endgroup::"
+
+          # Create attestation lineage file
+          cat > "${CHART}-attestation-lineage.json" <<EOF
+          {
+            "chart": "$CHART",
+            "version": "$VERSION",
+            "tag": "$TAG",
+            "package_digest": "$DIGEST",
+            "oci_digest": "$OCI_DIGEST",
+            "oci_url": "$OCI_REGISTRY/$CHART:$VERSION",
+            "attestations": $ATTESTATION_MAP,
+            "published_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "commit": "${{ github.sha }}"
+          }
+          EOF
+
+          # Collect assets
+          ASSETS=("$PACKAGE" "${PACKAGE}.sig" "${CHART}-attestation-lineage.json")
+
+          # Add optional assets if they exist
+          [[ -f "charts/$CHART/CHANGELOG.md" ]] && ASSETS+=("charts/$CHART/CHANGELOG.md")
+          [[ -f "charts/$CHART/README.md" ]] && ASSETS+=("charts/$CHART/README.md")
+
+          # Get changelog for release notes
+          CHANGELOG=$(extract_changelog_for_version "$CHART" "$VERSION")
+
+          # Generate release notes
+          RELEASE_NOTES=$(cat <<EOF
+          ## $CHART v$VERSION
+
+          ### Changelog
+
+          $CHANGELOG
+
+          ### Installation
+
+          \`\`\`bash
+          # Option 1: From GHCR (OCI) - Recommended
+          helm install $CHART oci://$OCI_REGISTRY/$CHART --version $VERSION
+
+          # Option 2: From Helm Repository
+          helm repo add arustydev https://charts.arusty.dev
+          helm repo update
+          helm install $CHART arustydev/$CHART --version $VERSION
+          \`\`\`
+
+          ### Verification
+
+          \`\`\`bash
+          # Verify OCI signature with Cosign
+          cosign verify $OCI_REGISTRY/$CHART@$OCI_DIGEST
+
+          # Verify attestations
+          gh attestation verify oci://$OCI_REGISTRY/$CHART:$VERSION --repo ${{ github.repository }}
+          \`\`\`
+
+          ### Attestation Lineage
+
+          See \`${CHART}-attestation-lineage.json\` in release assets for full attestation chain.
+
+          ---
+          *Released by W8: Atomic Release Publishing*
+          EOF
+          )
+
+          # Create release
+          echo "::group::Creating GitHub Release"
+          gh release create "$TAG" \
+            --title "$CHART v$VERSION" \
+            --notes "$RELEASE_NOTES" \
+            "${ASSETS[@]}"
+          echo "::endgroup::"
+
+          RELEASE_URL=$(gh release view "$TAG" --json url -q '.url')
+          echo "::notice::Created release: $RELEASE_URL"
+          echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
+          echo "release_exists=false" >> "$GITHUB_OUTPUT"
+
+      # Phase 8.9: Update Helm Repository Index
+      - name: Update index.yaml
+        if: steps.create-release.outputs.release_exists != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          CHART="${{ steps.detect-chart.outputs.chart }}"
+          VERSION="${{ steps.detect-chart.outputs.version }}"
+          TAG="${{ steps.detect-chart.outputs.tag }}"
+          PACKAGE="${{ steps.build-package.outputs.package }}"
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Set up authentication for push
+          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
+
+          # We're already on the release branch, just need to update index.yaml
+          # Copy package to current directory for helm repo index
+          cp "$PACKAGE" .
+
+          # Update index.yaml
+          # --url points to GitHub Releases download URL base
+          # --merge preserves existing entries
+          echo "::group::Updating index.yaml"
+          helm repo index . \
+            --url "https://github.com/${{ github.repository }}/releases/download" \
+            --merge index.yaml
+
+          # Show diff
+          git diff index.yaml || true
+          echo "::endgroup::"
+
+          # Commit and push
+          git add index.yaml
+          git commit -m "chore(release): update index.yaml for $CHART v$VERSION
+
+          Tag: $TAG
+          Release: https://github.com/${{ github.repository }}/releases/tag/$TAG"
+
+          git push origin HEAD:release
+
+          # Clean up package copy
+          rm -f "$(basename "$PACKAGE")"
+
+          echo "::notice::Updated index.yaml on release branch"
+
+      # Phase 8.10: Summary
+      - name: Summary
+        if: always()
+        run: |
+          echo "## W8 - Atomic Release Publishing Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Chart Information" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| **Chart** | ${{ steps.detect-chart.outputs.chart }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Version** | ${{ steps.detect-chart.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Tag** | \`${{ steps.detect-chart.outputs.tag }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Distribution" >> $GITHUB_STEP_SUMMARY
+          echo "| Channel | URL |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|-----|" >> $GITHUB_STEP_SUMMARY
+          echo "| **GHCR (OCI)** | \`${{ steps.publish-ghcr.outputs.oci_url }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **GitHub Release** | ${{ steps.create-release.outputs.release_url }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Helm Repo** | \`helm repo add arustydev https://charts.arusty.dev\` |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Security" >> $GITHUB_STEP_SUMMARY
+          echo "| Item | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| OCI Signature (Cosign) | Signed |" >> $GITHUB_STEP_SUMMARY
+          echo "| Package Signature (.sig) | Signed |" >> $GITHUB_STEP_SUMMARY
+          echo "| Attestation Lineage | Included |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Verification Commands" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "# Verify OCI signature" >> $GITHUB_STEP_SUMMARY
+          echo "cosign verify ${{ steps.publish-ghcr.outputs.oci_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "# Verify attestations" >> $GITHUB_STEP_SUMMARY
+          echo "gh attestation verify oci://${{ steps.publish-ghcr.outputs.oci_url }} --repo ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Implements Workflow 8 (W8) - Atomic Release Publishing, which publishes charts to multiple distribution channels when release PRs are merged.

### Trigger
- `push` to `release` branch with changes to `charts/**`

### Distribution Channels

| Channel | URL Pattern | Purpose |
|---------|-------------|---------|
| **GHCR (OCI)** | `oci://ghcr.io/<owner>/charts/<chart>` | Modern OCI-based distribution |
| **GitHub Releases** | Release assets with `.tgz`, `.sig`, JSON | Direct downloads |
| **Helm Repo** | `https://charts.arusty.dev` | Traditional `helm repo add` |

### What it does

1. **Chart Detection** (Phase 8.3)
   - Extracts chart from merge commit message
   - Validates tag exists (created by W6)

2. **Attestation Lineage** (Phase 8.4)
   - Retrieves attestation map from merged PR
   - Extracts attestations from tag annotation

3. **Build Package** (Phase 8.5)
   - Builds `.tgz` with `helm package`
   - Calculates SHA256 digest

4. **Publish to GHCR** (Phase 8.6)
   - Pushes to GHCR OCI registry (3 retries with backoff)
   - Signs with Cosign (keyless via OIDC)

5. **Create GitHub Release** (Phase 8.7)
   - Creates release with assets (idempotent - skips if exists)
   - Signs package blob (.tgz.sig)
   - Includes attestation lineage JSON
   - Comprehensive release notes

6. **Update index.yaml** (Phase 8.9)
   - Updates Helm repo index on release branch
   - Enables `helm repo add` distribution

### Security Features

- **Cosign keyless signing** for OCI artifacts
- **Package blob signatures** (.tgz.sig) for release assets
- **Attestation lineage JSON** with full provenance chain
- **GitHub App token** for pushing to protected release branch

### Test Plan

| Test | Status | Notes |
|------|--------|-------|
| YAML syntax valid | ✅ | Validated with Ruby YAML parser |
| Shell syntax valid | ✅ | `bash -n` passed |
| Workflow triggers on push to release | ⏳ | Requires merge + W6→W7 flow |
| Chart detection from commit | ⏳ | Logic reviewed |
| GHCR push with retry | ⏳ | Logic reviewed |
| Cosign signing | ⏳ | Requires runtime test |
| GitHub Release creation | ⏳ | Logic reviewed |
| index.yaml update | ⏳ | Logic reviewed |

**Note**: Runtime tests require the full W6→W7→W8 flow to be triggered.

### Files Changed

- `.github/workflows/atomic-release-publishing.yaml` - W8 workflow implementation
- `.claude/plans/chart-release-workflows/workflow-8/plan.md` - Updated plan with:
  - Resolved all open questions
  - Single-chart-per-merge assumption
  - Added Phase 8.9 (index.yaml update)
  - Marked all prerequisites complete

### Dependencies

- W6 workflow (creates tags and release PRs) ✅
- W7 workflow (validates and builds on PR) ✅
- `attestation-lib.sh` shared functions ✅
- `release-branch-protection` ruleset (ID: 11884271) ✅
- GitHub App for pushing to release branch ✅

---
*Auto-generated by W8 implementation*