### PR TITLE
fix(cloudflared): update chart source links to this repository

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -16,9 +16,9 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: Chart Source
-      url: https://github.com/community-charts/helm-charts
-    - name: Chart Usage Page
-      url: https://community-charts.github.io/docs/charts/cloudflared/usage
+      url: https://github.com/aRustyDev/helm-charts
+    - name: Chart Documentation
+      url: https://charts.arusty.dev/cloudflared/
     - name: Upstream Project
       url: https://github.com/cloudflare/cloudflared
     - name: Official Documentation


### PR DESCRIPTION
## Summary

Update Chart.yaml links to point to the correct repository.

### Changes
- Update Chart Source URL from `community-charts/helm-charts` to `aRustyDev/helm-charts`
- Rename "Chart Usage Page" to "Chart Documentation"
- Point documentation to `charts.arusty.dev/cloudflared/`

### Purpose

This PR is also used to test the W1→W8 workflow chain:
1. **W1** (validate-contribution) - Should trigger on this PR
2. **W2** (filter-charts) - Should trigger on merge to integration
3. **W5** (validate-semver-bump) - Should trigger on PR to main
4. **W6** (atomic-chart-tagging) - Should trigger on merge to main
5. **W7** (atomic-chart-releases) - Should trigger on PR to release
6. **W8** (atomic-release-publishing) - Should trigger on merge to release

### Test Plan

- [ ] W1 workflow triggers and passes
- [ ] Attestation map added to PR description
- [ ] Ready to merge to integration to continue chain

<!-- ATTESTATION_MAP
{"lint-test-v1.34.3":"16810705"}
-->