### PR TITLE
fix(ci): correct W2 branch naming and source paths

### DIFF
--- a/.github/workflows/filter-charts.yaml
+++ b/.github/workflows/filter-charts.yaml
@@ -10,7 +10,7 @@
 #   - process-charts: Create/update per-chart branches and PRs to main
 #
 # Each processed chart gets:
-#   - A dedicated `promote/<chart>` branch
+#   - A dedicated `charts/<chart>` branch
 #   - A PR to main with the attestation map from the source PR
 #
 # See: .claude/plans/chart-release-workflows/workflow-2/plan.md
@@ -179,7 +179,7 @@ jobs:
           ATTESTATION_MAP: ${{ needs.detect-changes.outputs.attestation_map }}
         run: |
           set -e
-          BRANCH="promote/$CHART"
+          BRANCH="charts/$CHART"
 
           echo "::group::Branch operations for $CHART"
 
@@ -189,8 +189,8 @@ jobs:
             git fetch origin "$BRANCH"
 
             # Check if we need to update
-            LOCAL_CHART_SHA=$(git rev-parse HEAD:"promote/$CHART" 2>/dev/null || echo "none")
-            REMOTE_CHART_SHA=$(git rev-parse "origin/$BRANCH:promote/$CHART" 2>/dev/null || echo "none")
+            LOCAL_CHART_SHA=$(git rev-parse HEAD:"charts/$CHART" 2>/dev/null || echo "none")
+            REMOTE_CHART_SHA=$(git rev-parse "origin/$BRANCH:charts/$CHART" 2>/dev/null || echo "none")
 
             if [[ "$LOCAL_CHART_SHA" == "$REMOTE_CHART_SHA" ]]; then
               echo "::notice::No changes to push for $CHART (already up to date)"
@@ -208,7 +208,7 @@ jobs:
           fi
 
           # Copy the chart directory from the integration branch commit
-          git checkout "${{ github.sha }}" -- "promote/$CHART/"
+          git checkout "${{ github.sha }}" -- "charts/$CHART/"
 
           # Check if there are changes to commit
           if git diff --cached --quiet && git diff --quiet; then
@@ -220,7 +220,7 @@ jobs:
           fi
 
           # Stage and commit
-          git add "promote/$CHART/"
+          git add "charts/$CHART/"
 
           # Create commit message with source PR reference
           COMMIT_MSG="chore($CHART): sync from integration"
@@ -262,7 +262,7 @@ jobs:
           ATTESTATION_MAP: ${{ needs.detect-changes.outputs.attestation_map }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          BRANCH="promote/$CHART"
+          BRANCH="charts/$CHART"
 
           echo "::group::PR operations for $CHART"
 
@@ -414,7 +414,7 @@ jobs:
           echo "|-------|--------|--------|" >> $GITHUB_STEP_SUMMARY
 
           for chart in $CHARTS; do
-            echo "| $chart | \`promote/$chart\` | :white_check_mark: Processed |" >> $GITHUB_STEP_SUMMARY
+            echo "| $chart | \`charts/$chart\` | :white_check_mark: Processed |" >> $GITHUB_STEP_SUMMARY
           done
           echo "" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
## Summary
- Change branch naming from `promote/<chart>` to `charts/<chart>`
- Fix source paths to use `charts/<chart>` (actual repo directory)
- Update summary table to reflect correct branch names

## Problem
W2 workflow failed because it was trying to checkout `promote/cloudflared/` but the chart is at `charts/cloudflared/` in the repo. The previous fix incorrectly changed the source path along with the branch name.

## Fix
- Branch name: `charts/<chart>` (this is the branch W2 creates for per-chart PRs)
- Source path: `charts/<chart>` (this is where charts actually live in the repo)

Error from failed run:
```
error: pathspec 'promote/cloudflared/' did not match any file(s) known to git
```