### PR TITLE
chore: sync W2 fix from main

### DIFF
--- a/.github/workflows/filter-charts.yaml
+++ b/.github/workflows/filter-charts.yaml
@@ -10,7 +10,7 @@
 #   - process-charts: Create/update per-chart branches and PRs to main
 #
 # Each processed chart gets:
-#   - A dedicated `promote/<chart>` branch
+#   - A dedicated `charts/<chart>` branch
 #   - A PR to main with the attestation map from the source PR
 #
 # See: .claude/plans/chart-release-workflows/workflow-2/plan.md
@@ -179,7 +179,7 @@ jobs:
           ATTESTATION_MAP: ${{ needs.detect-changes.outputs.attestation_map }}
         run: |
           set -e
-          BRANCH="promote/$CHART"
+          BRANCH="charts/$CHART"
 
           echo "::group::Branch operations for $CHART"
 
@@ -189,8 +189,8 @@ jobs:
             git fetch origin "$BRANCH"
 
             # Check if we need to update
-            LOCAL_CHART_SHA=$(git rev-parse HEAD:"promote/$CHART" 2>/dev/null || echo "none")
-            REMOTE_CHART_SHA=$(git rev-parse "origin/$BRANCH:promote/$CHART" 2>/dev/null || echo "none")
+            LOCAL_CHART_SHA=$(git rev-parse HEAD:"charts/$CHART" 2>/dev/null || echo "none")
+            REMOTE_CHART_SHA=$(git rev-parse "origin/$BRANCH:charts/$CHART" 2>/dev/null || echo "none")
 
             if [[ "$LOCAL_CHART_SHA" == "$REMOTE_CHART_SHA" ]]; then
               echo "::notice::No changes to push for $CHART (already up to date)"
@@ -208,7 +208,7 @@ jobs:
           fi
 
           # Copy the chart directory from the integration branch commit
-          git checkout "${{ github.sha }}" -- "promote/$CHART/"
+          git checkout "${{ github.sha }}" -- "charts/$CHART/"
 
           # Check if there are changes to commit
           if git diff --cached --quiet && git diff --quiet; then
@@ -220,7 +220,7 @@ jobs:
           fi
 
           # Stage and commit
-          git add "promote/$CHART/"
+          git add "charts/$CHART/"
 
           # Create commit message with source PR reference
           COMMIT_MSG="chore($CHART): sync from integration"
@@ -262,7 +262,7 @@ jobs:
           ATTESTATION_MAP: ${{ needs.detect-changes.outputs.attestation_map }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          BRANCH="promote/$CHART"
+          BRANCH="charts/$CHART"
 
           echo "::group::PR operations for $CHART"
 
@@ -414,7 +414,7 @@ jobs:
           echo "|-------|--------|--------|" >> $GITHUB_STEP_SUMMARY
 
           for chart in $CHARTS; do
-            echo "| $chart | \`promote/$chart\` | :white_check_mark: Processed |" >> $GITHUB_STEP_SUMMARY
+            echo "| $chart | \`charts/$chart\` | :white_check_mark: Processed |" >> $GITHUB_STEP_SUMMARY
           done
           echo "" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
## Summary
Sync the W2 workflow fix from main to integration.

## Changes
- Branch naming: `charts/<chart>` instead of `promote/<chart>`
- Source paths: `charts/<chart>` (actual repo directory)

This fix corrects the W2 workflow which was failing because it was looking for chart files at `promote/<chart>` when they are actually at `charts/<chart>` in the repo.