### PR TITLE
fix(ci): create per-chart branches from main, not integration

### DIFF
--- a/.github/workflows/filter-charts.yaml
+++ b/.github/workflows/filter-charts.yaml
@@ -203,8 +203,8 @@ jobs:
             # Reset branch to track remote, then update
             git checkout -B "$BRANCH" "origin/$BRANCH"
           else
-            echo "::notice::Creating new branch: $BRANCH"
-            git checkout -b "$BRANCH"
+            echo "::notice::Creating new branch: $BRANCH from origin/main"
+            git checkout -b "$BRANCH" origin/main
           fi
 
           # Copy the chart directory from the integration branch commit


### PR DESCRIPTION
## Summary
Fix W2 workflow to create per-chart branches from `origin/main` instead of current HEAD.

## Problem
W2 creates `charts/<chart>` branches and PRs them to `main`. But it was creating branches from HEAD (which is `integration`), causing:
```
No commits between main and charts/cloudflared
```

## Fix
Change branch creation from:
```bash
git checkout -b "$BRANCH"
```
to:
```bash
git checkout -b "$BRANCH" origin/main
```

This ensures the per-chart branch is based on `main`, so when we copy chart files from the integration commit and PR to main, there will be actual changes to merge.