### PR TITLE
docs: add labels strategy documentation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,6 +22,12 @@ Charts requiring external services are excluded from install tests but still lin
 | `validate-maintainers` | `true` | Ensures maintainer GitHub usernames are valid |
 | `check-version-increment` | `false` | Release-please handles versioning |
 
+### Labels Strategy
+Repository uses a structured labeling system for issues and PRs.
+
+- See [Labels Strategy](memory/repo-labels.md) for the full label list and usage guidelines
+- Key categories: Status (`pending`, `tagged`), Scope (`chart`, `cicd`), Kind (`bug`, `enhancement`), Flags (`automation`, `release`)
+
 ## Architecture Decision Records
 
 Full ADRs are located in `docs/src/adr/`:

--- a/.claude/memory/repo-labels.md
+++ b/.claude/memory/repo-labels.md
@@ -1,0 +1,81 @@
+# Repository Labels Strategy
+
+This document defines the labeling strategy for the aRustyDev/helm-charts repository.
+
+## Label Categories
+
+### Status Labels
+Labels indicating the current state in automated workflows.
+
+| Label | Description | Usage |
+|-------|-------------|-------|
+| `pending` | Awaiting automation to process | Applied by release-please when PR is created |
+| `tagged` | Tagged for release | Applied by release-please after release is tagged |
+
+### Scope Labels
+Labels indicating what area of the repository is affected.
+
+| Label | Description | Usage |
+|-------|-------------|-------|
+| `chart` | Related to Helm chart content or configuration | Chart additions, updates, or fixes |
+| `cicd` | CI/CD pipelines and automation infrastructure | Workflow changes, CI configuration |
+| `documentation` | Improvements or additions to documentation | README, docs, comments |
+| `dependencies` | Dependency updates and management | Dependabot PRs, dependency bumps |
+
+### Kind Labels
+Labels indicating the type of change.
+
+| Label | Description | Usage |
+|-------|-------------|-------|
+| `bug` | Something isn't working as expected | Bug reports and fixes |
+| `enhancement` | New feature or request | Feature requests and implementations |
+| `security` | Security-related issues or vulnerabilities | Security fixes, CVE responses |
+| `question` | Further information is requested | Questions from users |
+
+### Flag Labels
+Labels for workflow management and triage.
+
+| Label | Description | Usage |
+|-------|-------------|-------|
+| `automation` | Automated process or bot-managed work | Bot-created PRs, automated updates |
+| `release` | Release process and publishing | Release-related work |
+| `good first issue` | Good for newcomers | Issues suitable for new contributors |
+| `help wanted` | Extra attention is needed | Issues needing community help |
+| `duplicate` | This issue or pull request already exists | Duplicate issues |
+| `invalid` | This doesn't seem right | Invalid or off-topic issues |
+| `wontfix` | This will not be worked on | Intentionally not addressing |
+
+## Label Combinations
+
+### Common Patterns
+
+- **New chart**: `chart` + `enhancement`
+- **Chart bug fix**: `chart` + `bug`
+- **CI improvement**: `cicd` + `enhancement`
+- **Security fix**: `chart` + `security` or `cicd` + `security`
+- **Automated PR**: `automation` + scope label (e.g., `dependencies`)
+- **Release PR**: `release` + `pending` or `tagged`
+
+## Migration History
+
+Labels were consolidated on 2026-01-17:
+
+| Old Label | New Label | Reason |
+|-----------|-----------|--------|
+| `autorelease: pending` | `pending` | Simplified naming |
+| `autorelease: tagged` | `tagged` | Simplified naming |
+| `chart-update` | `chart` | Merged into single scope label |
+| `new-chart` | `chart` | Merged into single scope label |
+| `github-actions` | `cicd` | More descriptive name |
+
+## Automation Integration
+
+### Release-Please
+- Applies `pending` when creating release PRs
+- Applies `tagged` after successful release
+
+### Dependabot
+- Applies `dependencies` to dependency update PRs
+
+### W2 Filter Charts (Future)
+- Could apply `chart` + `automation` + `release` to promotion PRs


### PR DESCRIPTION
## Summary
Add documentation for the repository's labeling strategy.

## Changes
- Create `.claude/memory/repo-labels.md` with:
  - Full label list organized by category
  - Usage guidelines for each label
  - Common label combinations
  - Migration history from old label names
- Update `.claude/CLAUDE.md` to reference the labels strategy

## Label Categories
- **Status**: `pending`, `tagged` (for release automation)
- **Scope**: `chart`, `cicd`, `documentation`, `dependencies`
- **Kind**: `bug`, `enhancement`, `security`, `question`
- **Flags**: `automation`, `release`, `good first issue`, etc.