### PR TITLE
fix(ci): W5 grep pattern for excluded charts with comments

### DIFF
--- a/.github/workflows/validate-semver-bump.yaml
+++ b/.github/workflows/validate-semver-bump.yaml
@@ -170,8 +170,8 @@ jobs:
           CHART="${{ needs.validate-and-detect.outputs.chart }}"
           echo "::group::Installing chart: $CHART on K8s ${{ matrix.k8s_version }}"
 
-          # Check if chart is excluded from install tests
-          if grep -q "^  - $CHART$" ct-install.yaml 2>/dev/null; then
+          # Check if chart is excluded from install tests (handles trailing comments)
+          if grep -qE "^  - $CHART(\s|$)" ct-install.yaml 2>/dev/null; then
             echo "::warning::Chart $CHART is excluded from install tests (requires external services)"
             echo "skipped=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary
- Fix grep pattern in W5 K8s install test to properly detect excluded charts
- Previous pattern `^  - $CHART$` didn't match lines with trailing comments
- New pattern `^  - $CHART(\s|$)` matches chart name followed by whitespace or end-of-line

## Problem
The cloudflared chart is listed in ct-install.yaml's excluded-charts:
```yaml
excluded-charts:
  - cloudflared  # Requires real Cloudflare tunnel credentials
```

But the grep pattern required exact end-of-line, so the trailing comment caused the match to fail. This led to install tests running (and failing) for cloudflared.

## Test
```bash
CHART="cloudflared" && grep -qE "^  - $CHART(\s|$)" ct-install.yaml && echo "MATCHED"
# Output: MATCHED
```

---
*Generated with [Claude Code](https://claude.ai/code)*

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>