### PR TITLE
chore: sync W7/W8 workflows to release branch

### DIFF
--- a/.github/scripts/attestation-lib.sh
+++ b/.github/scripts/attestation-lib.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+# attestation-lib.sh - Shared library for attestation operations
+#
+# This library provides functions for managing attestation maps in PR descriptions,
+# verifying attestation chains, and detecting changed charts.
+#
+# Usage:
+#   source .github/scripts/attestation-lib.sh
+#
+# Required environment variables:
+#   GITHUB_REPOSITORY - The owner/repo (e.g., aRustyDev/helm-charts)
+#
+# Optional environment variables:
+#   GH_TOKEN or GITHUB_TOKEN - For API authentication
+
+set -euo pipefail
+
+# Attestation map markers
+readonly ATTESTATION_MAP_START="<!-- ATTESTATION_MAP"
+readonly ATTESTATION_MAP_END="-->"
+
+#######################################
+# Update the attestation map in a PR description
+#
+# Adds or updates an attestation ID for a given check name in the PR description.
+# Uses exponential backoff retry for concurrent updates.
+#
+# Arguments:
+#   $1 - check_name: Name of the check (e.g., "lint-test-v1.32.11")
+#   $2 - attestation_id: The attestation ID to store
+#   $3 - pr_number: PR number to update (optional, uses PR_NUMBER env var if not provided)
+#
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+update_attestation_map() {
+    local check_name="$1"
+    local attestation_id="$2"
+    local pr_number="${3:-${PR_NUMBER:-}}"
+
+    if [[ -z "$pr_number" ]]; then
+        echo "::error::PR number not provided and PR_NUMBER not set"
+        return 1
+    fi
+
+    if [[ -z "$check_name" || -z "$attestation_id" ]]; then
+        echo "::error::check_name and attestation_id are required"
+        return 1
+    fi
+
+    local max_retries=5
+    local retry_delay=1
+
+    for ((attempt = 1; attempt <= max_retries; attempt++)); do
+        echo "::debug::Updating attestation map (attempt $attempt/$max_retries)"
+
+        # Get current PR body
+        local body
+        body=$(gh pr view "$pr_number" --json body -q '.body' 2>/dev/null) || {
+            echo "::warning::Failed to fetch PR body, retrying..."
+            sleep "$retry_delay"
+            retry_delay=$((retry_delay * 2))
+            continue
+        }
+
+        # Extract existing map or create new one
+        local existing_map
+        existing_map=$(extract_attestation_map_from_body "$body")
+        if [[ -z "$existing_map" || "$existing_map" == "null" ]]; then
+            existing_map='{}'
+        fi
+
+        # Update map with new attestation
+        local updated_map
+        updated_map=$(echo "$existing_map" | jq -c --arg k "$check_name" --arg v "$attestation_id" '. + {($k): $v}')
+
+        # Build new body
+        local new_body
+        if echo "$body" | grep -qF "<!-- ATTESTATION_MAP"; then
+            # Replace existing map using awk for robustness
+            new_body=$(echo "$body" | awk -v map="$updated_map" '
+                /<!-- ATTESTATION_MAP/,/-->/ {
+                    if (/<!-- ATTESTATION_MAP/) {
+                        print "<!-- ATTESTATION_MAP"
+                        print map
+                        next
+                    }
+                    if (/-->/) {
+                        print "-->"
+                        next
+                    }
+                    next
+                }
+                { print }
+            ')
+        else
+            # Append new map
+            new_body="$body
+
+<!-- ATTESTATION_MAP
+$updated_map
+-->"
+        fi
+
+        # Update PR
+        if gh pr edit "$pr_number" --body "$new_body" 2>/dev/null; then
+            echo "::notice::Updated attestation map: $check_name = $attestation_id"
+            return 0
+        fi
+
+        echo "::warning::Failed to update PR body, retrying..."
+        sleep "$retry_delay"
+        retry_delay=$((retry_delay * 2))
+    done
+
+    echo "::error::Failed to update attestation map after $max_retries attempts"
+    return 1
+}
+
+#######################################
+# Extract attestation map from PR description
+#
+# Arguments:
+#   $1 - pr_number: PR number to read from
+#
+# Outputs:
+#   JSON object containing attestation IDs, or empty object if none found
+#######################################
+extract_attestation_map() {
+    local pr_number="$1"
+
+    if [[ -z "$pr_number" ]]; then
+        echo "::error::PR number is required"
+        return 1
+    fi
+
+    local body
+    body=$(gh pr view "$pr_number" --json body -q '.body' 2>/dev/null) || {
+        echo "::error::Failed to fetch PR body"
+        return 1
+    }
+
+    extract_attestation_map_from_body "$body"
+}
+
+#######################################
+# Extract attestation map from a body string
+#
+# Arguments:
+#   $1 - body: PR body content
+#
+# Outputs:
+#   JSON object containing attestation IDs, or {} if none found
+#######################################
+extract_attestation_map_from_body() {
+    local body="$1"
+
+    if [[ -z "$body" ]]; then
+        echo '{}'
+        return 0
+    fi
+
+    # Extract content between markers using awk for robustness
+    local map_content
+    map_content=$(echo "$body" | awk '
+        /<!-- ATTESTATION_MAP/,/-->/ {
+            if (!/<!-- ATTESTATION_MAP/ && !/-->/) print
+        }
+    ' | tr -d '\n' | xargs)
+
+    if [[ -z "$map_content" ]]; then
+        echo '{}'
+        return 0
+    fi
+
+    # Validate it's valid JSON
+    if echo "$map_content" | jq -e . >/dev/null 2>&1; then
+        echo "$map_content"
+    else
+        echo "::warning::Invalid JSON in attestation map, returning empty" >&2
+        echo '{}'
+    fi
+}
+
+#######################################
+# Verify all attestations in a map
+#
+# Arguments:
+#   $1 - attestation_map: JSON object of check_name -> attestation_id
+#   $2 - repo: Repository in owner/repo format (optional, uses GITHUB_REPOSITORY)
+#
+# Returns:
+#   0 if all attestations are valid, 1 if any fail
+#######################################
+verify_attestation_chain() {
+    local attestation_map="$1"
+    local repo="${2:-${GITHUB_REPOSITORY:-}}"
+
+    if [[ -z "$repo" ]]; then
+        echo "::error::Repository not provided and GITHUB_REPOSITORY not set"
+        return 1
+    fi
+
+    if [[ -z "$attestation_map" || "$attestation_map" == "{}" ]]; then
+        echo "::error::Empty attestation map provided"
+        return 1
+    fi
+
+    local failed=0
+    local total=0
+    local verified=0
+
+    # Iterate through all attestations
+    while IFS='=' read -r key value; do
+        ((total++))
+        local check_name
+        local attestation_id
+        check_name=$(echo "$key" | tr -d '"')
+        attestation_id=$(echo "$value" | tr -d '"')
+
+        echo "::group::Verifying attestation: $check_name"
+        echo "Attestation ID: $attestation_id"
+
+        if gh attestation verify \
+            --repo "$repo" \
+            --bundle-from-oci "oci://ghcr.io/$repo/attestations:$attestation_id" 2>/dev/null; then
+            echo "::notice::Verified: $check_name"
+            ((verified++))
+        else
+            # Try alternative verification method
+            if gh api "/repos/$repo/attestations/$attestation_id" >/dev/null 2>&1; then
+                echo "::notice::Verified via API: $check_name"
+                ((verified++))
+            else
+                echo "::error::Failed to verify: $check_name ($attestation_id)"
+                ((failed++))
+            fi
+        fi
+        echo "::endgroup::"
+    done < <(echo "$attestation_map" | jq -r 'to_entries[] | "\(.key)=\(.value)"')
+
+    echo "::notice::Attestation verification complete: $verified/$total verified, $failed failed"
+
+    if [[ $failed -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+#######################################
+# Detect charts that changed in a commit range
+#
+# Arguments:
+#   $1 - range: Git commit range (optional, defaults to HEAD~1..HEAD)
+#   $2 - base_branch: Base branch for comparison (optional, for PR context)
+#
+# Outputs:
+#   Space-separated list of chart names that changed
+#######################################
+detect_changed_charts() {
+    local range="${1:-HEAD~1..HEAD}"
+    local base_branch="${2:-}"
+
+    # If base_branch is provided, use it for comparison
+    if [[ -n "$base_branch" ]]; then
+        range="origin/$base_branch...HEAD"
+    fi
+
+    local charts
+    charts=$(git diff --name-only "$range" 2>/dev/null | \
+        grep '^charts/' | \
+        cut -d'/' -f2 | \
+        sort -u | \
+        tr '\n' ' ' | \
+        xargs)
+
+    if [[ -z "$charts" ]]; then
+        echo "::notice::No chart changes detected in range: $range" >&2
+    else
+        echo "::notice::Changed charts: $charts" >&2
+    fi
+
+    echo "$charts"
+}
+
+#######################################
+# Validate source branch for a PR
+#
+# Arguments:
+#   $1 - source_branch: The source branch of the PR
+#   $2 - allowed_pattern: Allowed branch pattern (exact match or glob)
+#
+# Returns:
+#   0 if valid, 1 if invalid
+#######################################
+validate_source_branch() {
+    local source_branch="$1"
+    local allowed_pattern="$2"
+
+    if [[ -z "$source_branch" || -z "$allowed_pattern" ]]; then
+        echo "::error::source_branch and allowed_pattern are required"
+        return 1
+    fi
+
+    # Check for exact match or glob pattern
+    # shellcheck disable=SC2053
+    if [[ "$source_branch" == $allowed_pattern ]]; then
+        echo "::notice::Source branch '$source_branch' matches allowed pattern '$allowed_pattern'"
+        return 0
+    fi
+
+    echo "::error::Invalid source branch: '$source_branch' (expected: '$allowed_pattern')"
+    return 1
+}
+
+#######################################
+# Get the source PR number from a merge commit
+#
+# Arguments:
+#   $1 - commit_sha: Commit SHA to check (optional, defaults to HEAD)
+#
+# Outputs:
+#   PR number if found, empty otherwise
+#######################################
+get_source_pr() {
+    local commit_sha="${1:-HEAD}"
+
+    # Try to extract PR number from merge commit message
+    local pr_number
+    pr_number=$(git log -1 --format="%s" "$commit_sha" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+
+    if [[ -n "$pr_number" ]]; then
+        echo "$pr_number"
+        return 0
+    fi
+
+    # Try GitHub API as fallback
+    local repo="${GITHUB_REPOSITORY:-}"
+    if [[ -n "$repo" ]]; then
+        pr_number=$(gh api "/repos/$repo/commits/$commit_sha/pulls" --jq '.[0].number' 2>/dev/null || true)
+        if [[ -n "$pr_number" && "$pr_number" != "null" ]]; then
+            echo "$pr_number"
+            return 0
+        fi
+    fi
+
+    echo ""
+}
+
+#######################################
+# Generate a subject digest for attestation
+#
+# Arguments:
+#   $1 - subject_content: Content to hash (file path or string)
+#   $2 - type: "file" or "string" (default: "string")
+#
+# Outputs:
+#   SHA256 digest in format "sha256:..."
+#######################################
+generate_subject_digest() {
+    local subject_content="$1"
+    local type="${2:-string}"
+
+    local digest
+    if [[ "$type" == "file" ]]; then
+        if [[ ! -f "$subject_content" ]]; then
+            echo "::error::File not found: $subject_content"
+            return 1
+        fi
+        digest=$(sha256sum "$subject_content" | cut -d' ' -f1)
+    else
+        digest=$(echo -n "$subject_content" | sha256sum | cut -d' ' -f1)
+    fi
+
+    echo "sha256:$digest"
+}
+
+#######################################
+# Log attestation details for debugging
+#
+# Arguments:
+#   $1 - subject_name: The attestation subject name
+#   $2 - subject_digest: The subject digest
+#   $3 - attestation_id: The resulting attestation ID (optional)
+#######################################
+log_attestation() {
+    local subject_name="$1"
+    local subject_digest="$2"
+    local attestation_id="${3:-pending}"
+
+    echo "::group::Attestation Details"
+    echo "Subject Name: $subject_name"
+    echo "Subject Digest: $subject_digest"
+    echo "Attestation ID: $attestation_id"
+    echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "::endgroup::"
+}
+
+#######################################
+# Extract changelog entries for a specific version
+#
+# Reads the CHANGELOG.md file for a chart and extracts the section
+# for the specified version. Expects Keep-a-Changelog format.
+#
+# Arguments:
+#   $1 - chart: Chart name
+#   $2 - version: Version to extract (e.g., "1.0.0")
+#
+# Outputs:
+#   Changelog content for the specified version, or fallback message
+#######################################
+extract_changelog_for_version() {
+    local chart="$1"
+    local version="$2"
+    local changelog_file="charts/$chart/CHANGELOG.md"
+
+    if [[ -z "$chart" || -z "$version" ]]; then
+        echo "No changelog available (missing chart or version)"
+        return 0
+    fi
+
+    if [[ ! -f "$changelog_file" ]]; then
+        echo "No changelog available for $chart"
+        return 0
+    fi
+
+    # Extract section from ## [VERSION] until next ## [ or end of file
+    # Using awk to handle the Keep-a-Changelog format
+    local changelog_content
+    changelog_content=$(awk -v ver="$version" '
+        /^## \[/ {
+            if (found) exit
+            if ($0 ~ "\\[" ver "\\]") found=1
+        }
+        found { print }
+    ' "$changelog_file")
+
+    if [[ -z "$changelog_content" ]]; then
+        echo "No changelog entries found for version $version"
+        return 0
+    fi
+
+    echo "$changelog_content"
+}
+
+# Export functions for use in subshells
+export -f update_attestation_map
+export -f extract_attestation_map
+export -f extract_attestation_map_from_body
+export -f verify_attestation_chain
+export -f detect_changed_charts
+export -f validate_source_branch
+export -f get_source_pr
+export -f generate_subject_digest
+export -f log_attestation
+export -f extract_changelog_for_version

--- a/.github/workflows/atomic-chart-releases.yaml
+++ b/.github/workflows/atomic-chart-releases.yaml
@@ -1,0 +1,385 @@
+name: W7 - Atomic Chart Releases
+
+on:
+  pull_request:
+    branches:
+      - release
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  pull-requests: write
+
+concurrency:
+  group: w7-release-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  validate-and-build:
+    runs-on: ubuntu-latest
+    outputs:
+      chart: ${{ steps.detect-chart.outputs.chart }}
+      version: ${{ steps.detect-chart.outputs.version }}
+      tag: ${{ steps.detect-chart.outputs.tag }}
+      package: ${{ steps.build-package.outputs.package }}
+      digest: ${{ steps.build-package.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for tag and diff operations
+
+      - name: Load secrets from 1Password
+        id: op-secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
+          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
+
+      # Phase 7.2: Source Branch Validation
+      - name: Validate Source Branch
+        run: |
+          HEAD_REF="${{ github.head_ref }}"
+          if [[ "$HEAD_REF" != "main" ]]; then
+            echo "::error::Only 'main' branch can merge to 'release'"
+            echo "::error::Source branch: $HEAD_REF"
+            exit 1
+          fi
+          echo "::notice::Source branch validated: $HEAD_REF"
+
+      # Phase 7.3: Chart Detection and Validation
+      - name: Detect and Validate Chart
+        id: detect-chart
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          # Extract from PR title "release: <chart>-v<version>"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          if [[ ! "$PR_TITLE" =~ ^release:\ ([a-z0-9-]+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
+            echo "::error::Invalid PR title format. Expected: 'release: <chart>-v<version>'"
+            echo "::error::Actual title: $PR_TITLE"
+            exit 1
+          fi
+
+          CHART="${BASH_REMATCH[1]}"
+          VERSION="${BASH_REMATCH[2]}"
+          TAG="${CHART}-v${VERSION}"
+
+          echo "::notice::PR title indicates chart: $CHART v$VERSION"
+
+          # SECURITY CHECK: Validate PR title matches actual files changed
+          # Prevents scenario where PR for chart-foo is titled as chart-bar
+          CHANGED_CHARTS=$(git diff --name-only origin/release...HEAD 2>/dev/null | grep '^charts/' | cut -d'/' -f2 | sort -u || true)
+          CHART_COUNT=$(echo "$CHANGED_CHARTS" | grep -c . || true)
+
+          if [[ "$CHART_COUNT" -eq 0 ]]; then
+            echo "::error::No chart changes detected in PR"
+            exit 1
+          fi
+
+          if [[ "$CHART_COUNT" -gt 1 ]]; then
+            echo "::error::Multiple charts changed in PR: $CHANGED_CHARTS"
+            echo "::error::Each release PR must contain exactly ONE chart"
+            exit 1
+          fi
+
+          ACTUAL_CHART=$(echo "$CHANGED_CHARTS" | head -1)
+          if [[ "$ACTUAL_CHART" != "$CHART" ]]; then
+            echo "::error::PR title mismatch!"
+            echo "::error::  Title claims: $CHART"
+            echo "::error::  Files changed: $ACTUAL_CHART"
+            echo "::error::This could indicate a mislabeled PR or attempted manipulation"
+            exit 1
+          fi
+
+          echo "::notice::Validated: PR title matches files changed ($CHART)"
+
+          # Fetch tags to ensure we have them
+          git fetch --tags
+
+          # Verify tag exists
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG does not exist"
+            echo "::error::W6 should have created this tag before opening the release PR"
+            exit 1
+          fi
+
+          echo "::notice::Validated: Tag $TAG exists"
+
+          # Verify Chart.yaml version matches PR title version
+          CHART_YAML="charts/$CHART/Chart.yaml"
+          if [[ ! -f "$CHART_YAML" ]]; then
+            echo "::error::Chart.yaml not found: $CHART_YAML"
+            exit 1
+          fi
+
+          CHART_YAML_VERSION=$(grep '^version:' "$CHART_YAML" | awk '{print $2}' | tr -d '"' | tr -d "'")
+          if [[ "$CHART_YAML_VERSION" != "$VERSION" ]]; then
+            echo "::error::Version mismatch!"
+            echo "::error::  PR title: $VERSION"
+            echo "::error::  Chart.yaml: $CHART_YAML_VERSION"
+            exit 1
+          fi
+
+          echo "::notice::Validated: Chart.yaml version matches PR title ($VERSION)"
+
+          echo "chart=$CHART" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      # Phase 7.4: Tag Attestation Verification
+      - name: Verify Tag Attestations
+        id: verify-attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          TAG="${{ steps.detect-chart.outputs.tag }}"
+          REPO="${{ github.repository }}"
+
+          echo "::group::Fetching tag annotation"
+          # Get tag annotation
+          ANNOTATION=$(git tag -l --format='%(contents)' "$TAG")
+
+          if [[ -z "$ANNOTATION" ]]; then
+            echo "::error::Tag $TAG has no annotation"
+            exit 1
+          fi
+
+          echo "Tag annotation:"
+          echo "$ANNOTATION"
+          echo "::endgroup::"
+
+          # Extract attestation lineage section
+          # Format: "- check_name: attestation_id"
+          ATTESTATION_SECTION=$(echo "$ANNOTATION" | sed -n '/^Attestation Lineage:/,/^$/p' | grep '^- ' || true)
+
+          if [[ -z "$ATTESTATION_SECTION" || "$ATTESTATION_SECTION" == *"No attestation data"* ]]; then
+            echo "::warning::No attestation data found in tag annotation"
+            echo "::warning::Proceeding without upstream attestation verification"
+            echo "verified_count=0" >> "$GITHUB_OUTPUT"
+            echo "attestation_ids=" >> "$GITHUB_OUTPUT"
+          else
+            VERIFIED=0
+            FAILED=0
+            ATTESTATION_IDS=""
+
+            while IFS= read -r line; do
+              # Parse "- check_name: attestation_id"
+              CHECK_NAME=$(echo "$line" | sed 's/^- //' | cut -d: -f1)
+              ATTESTATION_ID=$(echo "$line" | cut -d: -f2 | tr -d ' ')
+
+              echo "::group::Verifying: $CHECK_NAME"
+              echo "Attestation ID: $ATTESTATION_ID"
+
+              # Verify attestation exists via GitHub API
+              if gh api "/repos/$REPO/attestations/$ATTESTATION_ID" >/dev/null 2>&1; then
+                echo "::notice::Verified: $CHECK_NAME ($ATTESTATION_ID)"
+                ((VERIFIED++))
+                ATTESTATION_IDS="${ATTESTATION_IDS}${CHECK_NAME}:${ATTESTATION_ID},"
+              else
+                echo "::error::Failed to verify: $CHECK_NAME ($ATTESTATION_ID)"
+                ((FAILED++))
+              fi
+              echo "::endgroup::"
+            done <<< "$ATTESTATION_SECTION"
+
+            echo "::notice::Verification complete: $VERIFIED verified, $FAILED failed"
+
+            if [[ $FAILED -gt 0 ]]; then
+              echo "::error::Attestation verification failed"
+              exit 1
+            fi
+
+            echo "verified_count=$VERIFIED" >> "$GITHUB_OUTPUT"
+            echo "attestation_ids=$ATTESTATION_IDS" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Phase 7.5: Chart Package Building
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'latest'
+
+      - name: Build Chart Package
+        id: build-package
+        run: |
+          CHART="${{ steps.detect-chart.outputs.chart }}"
+          VERSION="${{ steps.detect-chart.outputs.version }}"
+
+          mkdir -p .cr-release-packages
+
+          echo "::group::Building chart package"
+          helm package "charts/$CHART" -d .cr-release-packages/
+          echo "::endgroup::"
+
+          PACKAGE_FILE=".cr-release-packages/${CHART}-${VERSION}.tgz"
+
+          if [[ ! -f "$PACKAGE_FILE" ]]; then
+            echo "::error::Package file not created: $PACKAGE_FILE"
+            exit 1
+          fi
+
+          # Calculate digest
+          DIGEST=$(sha256sum "$PACKAGE_FILE" | cut -d' ' -f1)
+
+          echo "::notice::Package built: $PACKAGE_FILE"
+          echo "::notice::Digest: sha256:$DIGEST"
+
+          echo "package=$PACKAGE_FILE" >> "$GITHUB_OUTPUT"
+          echo "digest=sha256:$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "package_name=${CHART}-${VERSION}.tgz" >> "$GITHUB_OUTPUT"
+
+      # Phase 7.6: Build Attestation Generation
+      - name: Generate Build Attestation
+        id: build-attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.build-package.outputs.package }}
+
+      # Phase 7.7: Overall Attestation Manifest
+      - name: Generate Attestation Manifest
+        id: manifest
+        run: |
+          CHART="${{ steps.detect-chart.outputs.chart }}"
+          VERSION="${{ steps.detect-chart.outputs.version }}"
+          TAG="${{ steps.detect-chart.outputs.tag }}"
+          DIGEST="${{ steps.build-package.outputs.digest }}"
+          BUILD_ATTESTATION_ID="${{ steps.build-attestation.outputs.bundle-path }}"
+          UPSTREAM_ATTESTATIONS="${{ steps.verify-attestations.outputs.attestation_ids }}"
+
+          # Create manifest JSON
+          MANIFEST=$(cat <<EOF
+          {
+            "version": "1.0",
+            "stage": "release-build",
+            "chart": {
+              "name": "$CHART",
+              "version": "$VERSION",
+              "digest": "$DIGEST",
+              "tag": "$TAG"
+            },
+            "pr": ${{ github.event.pull_request.number }},
+            "commit": "${{ github.sha }}",
+            "attestations": {
+              "upstream": "$UPSTREAM_ATTESTATIONS",
+              "build": "$BUILD_ATTESTATION_ID"
+            },
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          )
+
+          echo "$MANIFEST" > attestation-manifest.json
+          echo "::notice::Generated attestation manifest"
+          cat attestation-manifest.json
+
+          echo "manifest_file=attestation-manifest.json" >> "$GITHUB_OUTPUT"
+
+      # Phase 7.8: Artifact Upload (Optional - for inspection)
+      - name: Upload Chart Package
+        uses: actions/upload-artifact@v4
+        with:
+          name: chart-package-${{ steps.detect-chart.outputs.chart }}-${{ steps.detect-chart.outputs.version }}
+          path: |
+            ${{ steps.build-package.outputs.package }}
+            attestation-manifest.json
+          retention-days: 30
+
+      # Update PR Description with attestation summary
+      - name: Update PR Description
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          CHART="${{ steps.detect-chart.outputs.chart }}"
+          VERSION="${{ steps.detect-chart.outputs.version }}"
+          TAG="${{ steps.detect-chart.outputs.tag }}"
+          DIGEST="${{ steps.build-package.outputs.digest }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          VERIFIED_COUNT="${{ steps.verify-attestations.outputs.verified_count }}"
+
+          # Get current PR body
+          CURRENT_BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body')
+
+          # Check if we already have a W7 section
+          if echo "$CURRENT_BODY" | grep -q "### W7 Build Attestation"; then
+            echo "::notice::W7 section already exists in PR description, skipping update"
+            exit 0
+          fi
+
+          # Append W7 attestation info
+          NEW_BODY="$CURRENT_BODY
+
+          ---
+
+          ### W7 Build Attestation
+
+          | Field | Value |
+          |-------|-------|
+          | Chart | \`$CHART\` |
+          | Version | \`$VERSION\` |
+          | Tag | \`$TAG\` |
+          | Package Digest | \`$DIGEST\` |
+          | Upstream Attestations Verified | $VERIFIED_COUNT |
+          | Build Attestation | Generated |
+          | Timestamp | $(date -u +%Y-%m-%dT%H:%M:%SZ) |
+
+          <details>
+          <summary>Download Package</summary>
+
+          The chart package is available as a workflow artifact for inspection.
+          After merge, W8 will publish to the release branch and GHCR.
+
+          </details>
+
+          <!-- W7_ATTESTATION
+          ${{ steps.build-package.outputs.digest }}
+          -->"
+
+          gh pr edit "$PR_NUMBER" --body "$NEW_BODY"
+          echo "::notice::Updated PR description with W7 attestation info"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## W7 - Atomic Chart Releases Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Chart Information" >> $GITHUB_STEP_SUMMARY
+          echo "- **Chart**: ${{ steps.detect-chart.outputs.chart }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ steps.detect-chart.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag**: ${{ steps.detect-chart.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Build Information" >> $GITHUB_STEP_SUMMARY
+          echo "- **Package**: ${{ steps.build-package.outputs.package_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Digest**: ${{ steps.build-package.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Attestation" >> $GITHUB_STEP_SUMMARY
+          echo "- **Upstream Attestations Verified**: ${{ steps.verify-attestations.outputs.verified_count }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Attestation**: Generated" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
+          echo "1. Review the build attestation and package" >> $GITHUB_STEP_SUMMARY
+          echo "2. Merge this PR to trigger W8 (publish to GHCR and release branch)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/atomic-release-publishing.yaml
+++ b/.github/workflows/atomic-release-publishing.yaml
@@ -1,0 +1,431 @@
+name: W8 - Atomic Release Publishing
+
+on:
+  push:
+    branches:
+      - release
+    paths:
+      - 'charts/**'
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: w8-publish-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    outputs:
+      chart: ${{ steps.detect-chart.outputs.chart }}
+      version: ${{ steps.detect-chart.outputs.version }}
+      tag: ${{ steps.detect-chart.outputs.tag }}
+      oci_url: ${{ steps.publish-ghcr.outputs.oci_url }}
+      release_url: ${{ steps.create-release.outputs.release_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for tags and diff
+
+      - name: Load secrets from 1Password
+        id: op-secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
+          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
+
+      # Phase 8.2: Setup
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'latest'
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Phase 8.3: Chart Detection
+      - name: Detect Chart
+        id: detect-chart
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          # Get merge commit message
+          COMMIT_MSG=$(git log -1 --format="%s" HEAD)
+          echo "::debug::Commit message: $COMMIT_MSG"
+
+          # Try to extract from PR title in merge commit
+          # Format: "Merge pull request #X from ... " followed by PR title
+          # Or squash merge: "release: <chart>-v<version> (#X)"
+          if [[ "$COMMIT_MSG" =~ release:\ ([a-z0-9-]+)-v([0-9]+\.[0-9]+\.[0-9]+[^\ ]*) ]]; then
+            CHART="${BASH_REMATCH[1]}"
+            VERSION="${BASH_REMATCH[2]}"
+            echo "::notice::Extracted from commit message: $CHART v$VERSION"
+          else
+            # Fallback: detect from changed files
+            echo "::notice::Falling back to file detection"
+            CHART=$(git diff --name-only HEAD~1..HEAD | grep '^charts/' | cut -d'/' -f2 | sort -u | head -1)
+
+            if [[ -z "$CHART" ]]; then
+              echo "::error::Could not detect chart from commit"
+              exit 1
+            fi
+
+            VERSION=$(grep '^version:' "charts/$CHART/Chart.yaml" | awk '{print $2}' | tr -d '"' | tr -d "'")
+            echo "::notice::Detected from files: $CHART v$VERSION"
+          fi
+
+          TAG="${CHART}-v${VERSION}"
+
+          # Validate chart directory exists
+          if [[ ! -d "charts/$CHART" ]]; then
+            echo "::error::Chart directory not found: charts/$CHART"
+            exit 1
+          fi
+
+          # Validate tag exists
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG does not exist"
+            echo "::error::W6 should have created this tag"
+            exit 1
+          fi
+
+          echo "::notice::Chart: $CHART, Version: $VERSION, Tag: $TAG"
+
+          echo "chart=$CHART" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      # Phase 8.4: Attestation Lineage Retrieval
+      - name: Get Attestation Lineage
+        id: attestation-lineage
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          TAG="${{ steps.detect-chart.outputs.tag }}"
+
+          # Get PR number from merge commit
+          PR_NUMBER=$(get_source_pr HEAD)
+          echo "::notice::Source PR: ${PR_NUMBER:-not found}"
+
+          ATTESTATION_MAP="{}"
+          if [[ -n "$PR_NUMBER" ]]; then
+            # Extract from PR description (includes W7 build attestation)
+            ATTESTATION_MAP=$(extract_attestation_map "$PR_NUMBER") || ATTESTATION_MAP="{}"
+          fi
+
+          # Also get attestation lineage from tag annotation
+          TAG_ANNOTATION=$(git tag -l --format='%(contents)' "$TAG")
+          TAG_ATTESTATIONS=$(echo "$TAG_ANNOTATION" | sed -n '/^Attestation Lineage:/,/^$/p' | grep '^- ' || true)
+
+          echo "::group::Attestation Lineage"
+          echo "PR Attestation Map: $ATTESTATION_MAP"
+          echo "Tag Attestations:"
+          echo "$TAG_ATTESTATIONS"
+          echo "::endgroup::"
+
+          echo "attestation_map=$ATTESTATION_MAP" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      # Phase 8.5: Build Chart Package
+      - name: Build Chart Package
+        id: build-package
+        run: |
+          CHART="${{ steps.detect-chart.outputs.chart }}"
+          VERSION="${{ steps.detect-chart.outputs.version }}"
+
+          mkdir -p .cr-release-packages
+
+          echo "::group::Building chart package"
+          helm package "charts/$CHART" -d .cr-release-packages/
+          echo "::endgroup::"
+
+          PACKAGE_FILE=".cr-release-packages/${CHART}-${VERSION}.tgz"
+
+          if [[ ! -f "$PACKAGE_FILE" ]]; then
+            echo "::error::Package file not created: $PACKAGE_FILE"
+            exit 1
+          fi
+
+          DIGEST=$(sha256sum "$PACKAGE_FILE" | cut -d' ' -f1)
+
+          echo "::notice::Package: $PACKAGE_FILE"
+          echo "::notice::Digest: sha256:$DIGEST"
+
+          echo "package=$PACKAGE_FILE" >> "$GITHUB_OUTPUT"
+          echo "digest=sha256:$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "package_name=${CHART}-${VERSION}.tgz" >> "$GITHUB_OUTPUT"
+
+      # Phase 8.6: Publish to GHCR
+      - name: Publish to GHCR
+        id: publish-ghcr
+        run: |
+          CHART="${{ steps.detect-chart.outputs.chart }}"
+          VERSION="${{ steps.detect-chart.outputs.version }}"
+          PACKAGE="${{ steps.build-package.outputs.package }}"
+
+          # GHCR requires lowercase
+          REGISTRY="ghcr.io/${{ github.repository_owner }}/charts"
+          REGISTRY="${REGISTRY,,}"
+
+          MAX_RETRIES=3
+          RETRY_DELAY=5
+          OCI_DIGEST=""
+
+          for ((attempt=1; attempt<=MAX_RETRIES; attempt++)); do
+            echo "::group::Pushing to GHCR (attempt $attempt/$MAX_RETRIES)"
+
+            if PUSH_OUTPUT=$(helm push "$PACKAGE" "oci://$REGISTRY" 2>&1); then
+              echo "$PUSH_OUTPUT"
+              OCI_DIGEST=$(echo "$PUSH_OUTPUT" | grep -oP 'Digest: \Ksha256:[a-f0-9]+' || true)
+
+              if [[ -n "$OCI_DIGEST" ]]; then
+                echo "::notice::Pushed $CHART:$VERSION to GHCR"
+                echo "::notice::OCI Digest: $OCI_DIGEST"
+                echo "::endgroup::"
+                break
+              fi
+            fi
+
+            echo "::warning::Push attempt $attempt failed"
+            echo "$PUSH_OUTPUT"
+            echo "::endgroup::"
+
+            if [[ $attempt -lt $MAX_RETRIES ]]; then
+              echo "Retrying in ${RETRY_DELAY}s..."
+              sleep $RETRY_DELAY
+              RETRY_DELAY=$((RETRY_DELAY * 2))
+            else
+              echo "::error::Failed to push to GHCR after $MAX_RETRIES attempts"
+              exit 1
+            fi
+          done
+
+          # Sign with Cosign (keyless via OIDC)
+          echo "::group::Signing with Cosign"
+          cosign sign --yes "$REGISTRY/$CHART@$OCI_DIGEST"
+          echo "::notice::Signed $CHART@$OCI_DIGEST"
+          echo "::endgroup::"
+
+          echo "oci_digest=$OCI_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "oci_url=$REGISTRY/$CHART:$VERSION" >> "$GITHUB_OUTPUT"
+          echo "oci_registry=$REGISTRY" >> "$GITHUB_OUTPUT"
+
+      # Phase 8.7: Create GitHub Release
+      - name: Create GitHub Release
+        id: create-release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          CHART="${{ steps.detect-chart.outputs.chart }}"
+          VERSION="${{ steps.detect-chart.outputs.version }}"
+          TAG="${{ steps.detect-chart.outputs.tag }}"
+          PACKAGE="${{ steps.build-package.outputs.package }}"
+          DIGEST="${{ steps.build-package.outputs.digest }}"
+          OCI_DIGEST="${{ steps.publish-ghcr.outputs.oci_digest }}"
+          OCI_REGISTRY="${{ steps.publish-ghcr.outputs.oci_registry }}"
+          ATTESTATION_MAP='${{ steps.attestation-lineage.outputs.attestation_map }}'
+
+          # Check if release already exists
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::Release $TAG already exists, skipping creation"
+            RELEASE_URL=$(gh release view "$TAG" --json url -q '.url')
+            echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
+            echo "release_exists=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Sign package blob
+          echo "::group::Signing package blob"
+          cosign sign-blob --yes --output-signature "${PACKAGE}.sig" "$PACKAGE"
+          echo "::endgroup::"
+
+          # Create attestation lineage file
+          cat > "${CHART}-attestation-lineage.json" <<EOF
+          {
+            "chart": "$CHART",
+            "version": "$VERSION",
+            "tag": "$TAG",
+            "package_digest": "$DIGEST",
+            "oci_digest": "$OCI_DIGEST",
+            "oci_url": "$OCI_REGISTRY/$CHART:$VERSION",
+            "attestations": $ATTESTATION_MAP,
+            "published_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "commit": "${{ github.sha }}"
+          }
+          EOF
+
+          # Collect assets
+          ASSETS=("$PACKAGE" "${PACKAGE}.sig" "${CHART}-attestation-lineage.json")
+
+          # Add optional assets if they exist
+          [[ -f "charts/$CHART/CHANGELOG.md" ]] && ASSETS+=("charts/$CHART/CHANGELOG.md")
+          [[ -f "charts/$CHART/README.md" ]] && ASSETS+=("charts/$CHART/README.md")
+
+          # Get changelog for release notes
+          CHANGELOG=$(extract_changelog_for_version "$CHART" "$VERSION")
+
+          # Generate release notes
+          RELEASE_NOTES=$(cat <<EOF
+          ## $CHART v$VERSION
+
+          ### Changelog
+
+          $CHANGELOG
+
+          ### Installation
+
+          \`\`\`bash
+          # Option 1: From GHCR (OCI) - Recommended
+          helm install $CHART oci://$OCI_REGISTRY/$CHART --version $VERSION
+
+          # Option 2: From Helm Repository
+          helm repo add arustydev https://charts.arusty.dev
+          helm repo update
+          helm install $CHART arustydev/$CHART --version $VERSION
+          \`\`\`
+
+          ### Verification
+
+          \`\`\`bash
+          # Verify OCI signature with Cosign
+          cosign verify $OCI_REGISTRY/$CHART@$OCI_DIGEST
+
+          # Verify attestations
+          gh attestation verify oci://$OCI_REGISTRY/$CHART:$VERSION --repo ${{ github.repository }}
+          \`\`\`
+
+          ### Attestation Lineage
+
+          See \`${CHART}-attestation-lineage.json\` in release assets for full attestation chain.
+
+          ---
+          *Released by W8: Atomic Release Publishing*
+          EOF
+          )
+
+          # Create release
+          echo "::group::Creating GitHub Release"
+          gh release create "$TAG" \
+            --title "$CHART v$VERSION" \
+            --notes "$RELEASE_NOTES" \
+            "${ASSETS[@]}"
+          echo "::endgroup::"
+
+          RELEASE_URL=$(gh release view "$TAG" --json url -q '.url')
+          echo "::notice::Created release: $RELEASE_URL"
+          echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
+          echo "release_exists=false" >> "$GITHUB_OUTPUT"
+
+      # Phase 8.9: Update Helm Repository Index
+      - name: Update index.yaml
+        if: steps.create-release.outputs.release_exists != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          CHART="${{ steps.detect-chart.outputs.chart }}"
+          VERSION="${{ steps.detect-chart.outputs.version }}"
+          TAG="${{ steps.detect-chart.outputs.tag }}"
+          PACKAGE="${{ steps.build-package.outputs.package }}"
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Set up authentication for push
+          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
+
+          # We're already on the release branch, just need to update index.yaml
+          # Copy package to current directory for helm repo index
+          cp "$PACKAGE" .
+
+          # Update index.yaml
+          # --url points to GitHub Releases download URL base
+          # --merge preserves existing entries
+          echo "::group::Updating index.yaml"
+          helm repo index . \
+            --url "https://github.com/${{ github.repository }}/releases/download" \
+            --merge index.yaml
+
+          # Show diff
+          git diff index.yaml || true
+          echo "::endgroup::"
+
+          # Commit and push
+          git add index.yaml
+          git commit -m "chore(release): update index.yaml for $CHART v$VERSION
+
+          Tag: $TAG
+          Release: https://github.com/${{ github.repository }}/releases/tag/$TAG"
+
+          git push origin HEAD:release
+
+          # Clean up package copy
+          rm -f "$(basename "$PACKAGE")"
+
+          echo "::notice::Updated index.yaml on release branch"
+
+      # Phase 8.10: Summary
+      - name: Summary
+        if: always()
+        run: |
+          echo "## W8 - Atomic Release Publishing Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Chart Information" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| **Chart** | ${{ steps.detect-chart.outputs.chart }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Version** | ${{ steps.detect-chart.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Tag** | \`${{ steps.detect-chart.outputs.tag }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Distribution" >> $GITHUB_STEP_SUMMARY
+          echo "| Channel | URL |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|-----|" >> $GITHUB_STEP_SUMMARY
+          echo "| **GHCR (OCI)** | \`${{ steps.publish-ghcr.outputs.oci_url }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **GitHub Release** | ${{ steps.create-release.outputs.release_url }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Helm Repo** | \`helm repo add arustydev https://charts.arusty.dev\` |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Security" >> $GITHUB_STEP_SUMMARY
+          echo "| Item | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| OCI Signature (Cosign) | Signed |" >> $GITHUB_STEP_SUMMARY
+          echo "| Package Signature (.sig) | Signed |" >> $GITHUB_STEP_SUMMARY
+          echo "| Attestation Lineage | Included |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Verification Commands" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "# Verify OCI signature" >> $GITHUB_STEP_SUMMARY
+          echo "cosign verify ${{ steps.publish-ghcr.outputs.oci_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "# Verify attestations" >> $GITHUB_STEP_SUMMARY
+          echo "gh attestation verify oci://${{ steps.publish-ghcr.outputs.oci_url }} --repo ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Adds W7 and W8 workflow files to the release branch.

GitHub requires workflow files to exist on the base branch for PR-triggered workflows. Without these files on release, W7 won't trigger when release PRs are opened.

## Files Added
- `.github/workflows/atomic-chart-releases.yaml` (W7)
- `.github/workflows/atomic-release-publishing.yaml` (W8)
- `.github/scripts/attestation-lib.sh` (shared library)

---
*Generated with [Claude Code](https://claude.ai/code)*