### PR TITLE
feat(cloudflared): add ingress and private-network keywords

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -55,6 +55,8 @@ keywords:
   - access
   - network
   - connectivity
+  - ingress
+  - private-network
 kubeVersion: '>=1.21.0-0'
 maintainers:
   - email: adam@arustydev.io


### PR DESCRIPTION
## Summary

Add additional keywords for improved discoverability on ArtifactHub:
- `ingress`: cloudflared can expose services via tunnels
- `private-network`: enables private network access through Cloudflare

## Test Plan

This PR tests the full workflow pipeline:
1. **W1** (this PR): Validate contribution with lint, ArtifactHub lint, commit validation
2. **W2**: On merge, create `charts/cloudflared` branch and PR to main
3. **W5**: Validate PR to main, run K8s tests, bump version
4. **Release**: On merge to main, tag, package, publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ATTESTATION_MAP
{"artifacthub-lint":"16830461"}
-->