### PR TITLE
feat(cloudflared): add priorityClassName support

### DIFF
--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -120,3 +120,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}

--- a/charts/cloudflared/values.schema.json
+++ b/charts/cloudflared/values.schema.json
@@ -9,6 +9,13 @@
       "title": "affinity",
       "type": "object"
     },
+    "priorityClassName": {
+      "default": "",
+      "description": "Priority class name for pod scheduling. For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/",
+      "required": [],
+      "title": "priorityClassName",
+      "type": "string"
+    },
     "metrics": {
       "additionalProperties": false,
       "description": "Prometheus metrics configuration. Cloudflared exposes metrics on port 2000 by default.",

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -165,6 +165,9 @@ tolerations:
 # -- For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
+# -- Priority class name for pod scheduling. For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+priorityClassName: ""
+
 # -- Prometheus metrics configuration. Cloudflared exposes metrics on port 2000 by default.
 metrics:
   # -- Enable metrics endpoint


### PR DESCRIPTION
## Summary

- Add `priorityClassName` option to values.yaml for pod scheduling priority
- Add template logic to deployment.yaml to apply priorityClassName when set
- Update values.schema.json with new property

This allows users to configure pod scheduling priority for cloudflared pods, useful for production or critical workloads.

## Test plan

- [ ] Verify W1 validation passes (lint, ArtifactHub, commit validation)
- [ ] Verify auto-merge behavior

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- ATTESTATION_MAP
{"artifacthub-lint":"16872682"}
-->