### PR TITLE
docs: add attestation documentation and E2E tests

### DIFF
--- a/.claude/plans/chart-release-workflows/tests/plan.md
+++ b/.claude/plans/chart-release-workflows/tests/plan.md
@@ -22,20 +22,20 @@ Developer PR → W1 (Validate) → Auto-Merge → integration
 
 ### Repository Configuration
 
-| Requirement | Location | Value |
-|-------------|----------|-------|
-| Auto-merge enabled | Settings → General → Pull Requests | ✓ Allow auto-merge |
-| `AUTO_MERGE_ALLOWED_BRANCHES` | Settings → Secrets and variables → Actions → Variables | `integration` |
-| Branch protection (integration) | Settings → Branches | Require PR, status checks |
-| Branch protection (main) | Settings → Branches | Require PR, status checks, review |
-| CODEOWNERS | `.github/CODEOWNERS` | Lists trusted contributors |
+| Requirement                     | Location                                               | Value                             |
+| ------------------------------- | ------------------------------------------------------ | --------------------------------- |
+| Auto-merge enabled              | Settings → General → Pull Requests                     | ✓ Allow auto-merge                |
+| `AUTO_MERGE_ALLOWED_BRANCHES`   | Settings → Secrets and variables → Actions → Variables | `integration`                     |
+| Branch protection (integration) | Settings → Branches                                    | Require PR, status checks         |
+| Branch protection (main)        | Settings → Branches                                    | Require PR, status checks, review |
+| CODEOWNERS                      | `.github/CODEOWNERS`                                   | Lists trusted contributors        |
 
 ### Test User Accounts
 
-| Account | Purpose | Requirements |
-|---------|---------|--------------|
-| Trusted User | Tests pass scenarios | Listed in CODEOWNERS, has signing key |
-| Untrusted User | Tests fail scenarios | NOT in CODEOWNERS |
+| Account        | Purpose              | Requirements                          |
+| -------------- | -------------------- | ------------------------------------- |
+| Trusted User   | Tests pass scenarios | Listed in CODEOWNERS, has signing key |
+| Untrusted User | Tests fail scenarios | NOT in CODEOWNERS                     |
 
 ### Test Chart
 
@@ -55,33 +55,33 @@ appVersion: "1.0.0"
 
 ## Test Scenarios
 
-### Auto-Merge Workflow (`auto-merge-integration.yaml`)
+### Auto-Merge Workflow (`auto-merge.yaml`)
 
 #### Controls
 
-| ID | Control | Code Location |
-|----|---------|---------------|
-| AM-C1 | W1 must succeed | `workflow_run.conclusion == 'success'` |
-| AM-C2 | Must be PR event | `workflow_run.event == 'pull_request'` |
-| AM-C3 | PR targets allowed branch | `ALLOWED_BASE_BRANCHES` check |
-| AM-C4 | PR must be open | `--state open` filter |
-| AM-C5 | Author in CODEOWNERS | `grep -q "@$PR_AUTHOR"` |
-| AM-C6 | All commits signed | `.commit.verification.verified` |
+| ID    | Control                   | Code Location                          |
+| ----- | ------------------------- | -------------------------------------- |
+| AM-C1 | W1 must succeed           | `workflow_run.conclusion == 'success'` |
+| AM-C2 | Must be PR event          | `workflow_run.event == 'pull_request'` |
+| AM-C3 | PR targets allowed branch | `ALLOWED_BASE_BRANCHES` check          |
+| AM-C4 | PR must be open           | `--state open` filter                  |
+| AM-C5 | Author in CODEOWNERS      | `grep -q "@$PR_AUTHOR"`                |
+| AM-C6 | All commits signed        | `.commit.verification.verified`        |
 
 #### Test Matrix
 
-| Test ID | Control | Scenario | Expected | Cleanup |
-|---------|---------|----------|----------|---------|
-| AM-T1 | AM-C1 | W1 fails (invalid Chart.yaml) | Workflow doesn't trigger | Delete branch |
-| AM-T2 | AM-C2 | W1 via workflow_dispatch | Job skips (`event != 'pull_request'`) | N/A |
-| AM-T3 | AM-C3 | PR targets `main` | "branch_not_allowed" warning | Delete branch, close PR |
-| AM-T4 | AM-C4 | Close PR before workflow runs | "No open PR found" | Delete branch |
-| AM-T5 | AM-C5 | Author NOT in CODEOWNERS | Trust check fails | Delete branch, close PR |
-| AM-T6 | AM-C5 | Author IN CODEOWNERS | Trust check passes | Continue to AM-T7 |
-| AM-T7 | AM-C6 | Unsigned commits | Verification fails | Delete branch, close PR |
-| AM-T8 | AM-C6 | All commits signed | Verification passes | Continue to merge |
-| AM-T9 | ALL | Trusted + Verified | Auto-merge ENABLED | Merge completes |
-| AM-T10 | ALL | Untrusted + Verified | Auto-merge NOT enabled | Manual merge required |
+| Test ID | Control | Scenario                      | Expected                              | Cleanup                 |
+| ------- | ------- | ----------------------------- | ------------------------------------- | ----------------------- |
+| AM-T1   | AM-C1   | W1 fails (invalid Chart.yaml) | Workflow doesn't trigger              | Delete branch           |
+| AM-T2   | AM-C2   | W1 via workflow_dispatch      | Job skips (`event != 'pull_request'`) | N/A                     |
+| AM-T3   | AM-C3   | PR targets `main`             | "branch_not_allowed" warning          | Delete branch, close PR |
+| AM-T4   | AM-C4   | Close PR before workflow runs | "No open PR found"                    | Delete branch           |
+| AM-T5   | AM-C5   | Author NOT in CODEOWNERS      | Trust check fails                     | Delete branch, close PR |
+| AM-T6   | AM-C5   | Author IN CODEOWNERS          | Trust check passes                    | Continue to AM-T7       |
+| AM-T7   | AM-C6   | Unsigned commits              | Verification fails                    | Delete branch, close PR |
+| AM-T8   | AM-C6   | All commits signed            | Verification passes                   | Continue to merge       |
+| AM-T9   | ALL     | Trusted + Verified            | Auto-merge ENABLED                    | Merge completes         |
+| AM-T10  | ALL     | Untrusted + Verified          | Auto-merge NOT enabled                | Manual merge required   |
 
 ---
 
@@ -89,26 +89,26 @@ appVersion: "1.0.0"
 
 #### Controls
 
-| ID | Control | Code Location |
-|----|---------|---------------|
-| W2-C1 | Trigger on integration push | `push.branches: [integration]` |
-| W2-C2 | Only process charts/** changes | `paths: ['charts/**']` |
-| W2-C3 | Chart must have Chart.yaml | `if [[ -f "charts/$dir/Chart.yaml" ]]` |
-| W2-C4 | Concurrency control | `group: w2-filter-charts` |
-| W2-C5 | Create charts/<chart> branch | Branch creation logic |
-| W2-C6 | Create PR to main | `gh pr create --base main` |
+| ID    | Control                          | Code Location                          |
+| ----- | -------------------------------- | -------------------------------------- |
+| W2-C1 | Trigger on integration push      | `push.branches: [integration]`         |
+| W2-C2 | Only process charts/\*\* changes | `paths: ['charts/**']`                 |
+| W2-C3 | Chart must have Chart.yaml       | `if [[ -f "charts/$dir/Chart.yaml" ]]` |
+| W2-C4 | Concurrency control              | `group: w2-filter-charts`              |
+| W2-C5 | Create charts/<chart> branch     | Branch creation logic                  |
+| W2-C6 | Create PR to main                | `gh pr create --base main`             |
 
 #### Test Matrix
 
-| Test ID | Control | Scenario | Expected | Cleanup |
-|---------|---------|----------|----------|---------|
-| W2-T1 | W2-C1 | Push to integration (not charts/) | Workflow doesn't run | N/A |
-| W2-T2 | W2-C2 | Push to main (not integration) | Workflow doesn't run | N/A |
-| W2-T3 | W2-C3 | Change file in charts/ but not a chart | Skipped with notice | N/A |
-| W2-T4 | W2-C4 | Concurrent pushes to integration | Second waits or cancels | N/A |
-| W2-T5 | W2-C5 | Single chart change | Creates `charts/<chart>` branch | Delete branch |
-| W2-T6 | W2-C5 | Multiple chart changes | Creates multiple branches | Delete branches |
-| W2-T7 | W2-C6 | PR already exists for branch | Updates existing PR | N/A |
+| Test ID | Control | Scenario                               | Expected                        | Cleanup         |
+| ------- | ------- | -------------------------------------- | ------------------------------- | --------------- |
+| W2-T1   | W2-C1   | Push to integration (not charts/)      | Workflow doesn't run            | N/A             |
+| W2-T2   | W2-C2   | Push to main (not integration)         | Workflow doesn't run            | N/A             |
+| W2-T3   | W2-C3   | Change file in charts/ but not a chart | Skipped with notice             | N/A             |
+| W2-T4   | W2-C4   | Concurrent pushes to integration       | Second waits or cancels         | N/A             |
+| W2-T5   | W2-C5   | Single chart change                    | Creates `charts/<chart>` branch | Delete branch   |
+| W2-T6   | W2-C5   | Multiple chart changes                 | Creates multiple branches       | Delete branches |
+| W2-T7   | W2-C6   | PR already exists for branch           | Updates existing PR             | N/A             |
 
 ---
 
@@ -116,35 +116,35 @@ appVersion: "1.0.0"
 
 #### Controls
 
-| ID | Control | Code Location |
-|----|---------|---------------|
-| W5-C1 | PR targets main | `pull_request.branches: [main]` |
-| W5-C2 | Dispatch actor validation | `ALLOWED_DISPATCH_ACTORS` check |
-| W5-C3 | Source branch pattern | `^charts/[a-z0-9-]+$` or `^integration/[a-z0-9-]+$` |
-| W5-C4 | Chart must exist | `has_charts == 'true'` |
-| W5-C5 | ArtifactHub lint pass | `ah lint --kind helm` |
-| W5-C6 | Helm lint pass | `ct lint` |
-| W5-C7 | K8s matrix tests pass | `ct install` on v1.32, v1.33, v1.34 |
-| W5-C8 | Version bump logic | Conventional commit parsing |
-| W5-C9 | Cleanup on merge | Delete source branch |
+| ID    | Control                   | Code Location                                       |
+| ----- | ------------------------- | --------------------------------------------------- |
+| W5-C1 | PR targets main           | `pull_request.branches: [main]`                     |
+| W5-C2 | Dispatch actor validation | `ALLOWED_DISPATCH_ACTORS` check                     |
+| W5-C3 | Source branch pattern     | `^charts/[a-z0-9-]+$` or `^integration/[a-z0-9-]+$` |
+| W5-C4 | Chart must exist          | `has_charts == 'true'`                              |
+| W5-C5 | ArtifactHub lint pass     | `ah lint --kind helm`                               |
+| W5-C6 | Helm lint pass            | `ct lint`                                           |
+| W5-C7 | K8s matrix tests pass     | `ct install` on v1.32, v1.33, v1.34                 |
+| W5-C8 | Version bump logic        | Conventional commit parsing                         |
+| W5-C9 | Cleanup on merge          | Delete source branch                                |
 
 #### Test Matrix
 
-| Test ID | Control | Scenario | Expected | Cleanup |
-|---------|---------|----------|----------|---------|
-| W5-T1 | W5-C1 | PR targets integration | Workflow doesn't run | Close PR |
-| W5-T2 | W5-C2 | Dispatch from unauthorized actor | "Unauthorized actor" error | N/A |
-| W5-T3 | W5-C2 | Dispatch from github-actions[bot] | Actor validated | Continue |
-| W5-T4 | W5-C3 | PR from `feature/` branch | "does not match expected pattern" | Close PR |
-| W5-T5 | W5-C3 | PR from `charts/test` branch | Branch validated | Continue |
-| W5-T6 | W5-C4 | PR with no chart changes | Skip validation jobs | Close PR |
-| W5-T7 | W5-C5 | Chart missing ArtifactHub metadata | Lint fails | Fix and retry |
-| W5-T8 | W5-C6 | Chart with Helm lint errors | ct lint fails | Fix and retry |
-| W5-T9 | W5-C7 | Chart install fails on K8s 1.32 | Matrix job fails | Fix and retry |
-| W5-T10 | W5-C8 | `fix(chart):` commit | Patch version bump | Verify Chart.yaml |
-| W5-T11 | W5-C8 | `feat(chart):` commit | Minor version bump | Verify Chart.yaml |
-| W5-T12 | W5-C8 | `feat(chart)!:` commit | Major version bump | Verify Chart.yaml |
-| W5-T13 | W5-C9 | Merge PR to main | Source branch deleted | Verify deletion |
+| Test ID | Control | Scenario                           | Expected                          | Cleanup           |
+| ------- | ------- | ---------------------------------- | --------------------------------- | ----------------- |
+| W5-T1   | W5-C1   | PR targets integration             | Workflow doesn't run              | Close PR          |
+| W5-T2   | W5-C2   | Dispatch from unauthorized actor   | "Unauthorized actor" error        | N/A               |
+| W5-T3   | W5-C2   | Dispatch from github-actions[bot]  | Actor validated                   | Continue          |
+| W5-T4   | W5-C3   | PR from `feature/` branch          | "does not match expected pattern" | Close PR          |
+| W5-T5   | W5-C3   | PR from `charts/test` branch       | Branch validated                  | Continue          |
+| W5-T6   | W5-C4   | PR with no chart changes           | Skip validation jobs              | Close PR          |
+| W5-T7   | W5-C5   | Chart missing ArtifactHub metadata | Lint fails                        | Fix and retry     |
+| W5-T8   | W5-C6   | Chart with Helm lint errors        | ct lint fails                     | Fix and retry     |
+| W5-T9   | W5-C7   | Chart install fails on K8s 1.32    | Matrix job fails                  | Fix and retry     |
+| W5-T10  | W5-C8   | `fix(chart):` commit               | Patch version bump                | Verify Chart.yaml |
+| W5-T11  | W5-C8   | `feat(chart):` commit              | Minor version bump                | Verify Chart.yaml |
+| W5-T12  | W5-C8   | `feat(chart)!:` commit             | Major version bump                | Verify Chart.yaml |
+| W5-T13  | W5-C9   | Merge PR to main                   | Source branch deleted             | Verify deletion   |
 
 ---
 
@@ -152,31 +152,99 @@ appVersion: "1.0.0"
 
 #### Controls
 
-| ID | Control | Code Location |
-|----|---------|---------------|
-| R-C1 | Trigger on main push | `push.branches: [main]` |
-| R-C2 | Only process charts/** | `paths: ['charts/**']` |
-| R-C3 | Tag doesn't already exist | `git rev-parse "$TAG_NAME"` check |
-| R-C4 | Tag points to correct commit | Compare existing tag SHA |
-| R-C5 | Chart.yaml has version | `VERSION=$(grep '^version:')` |
-| R-C6 | Package attestation | `attest-build-provenance` |
-| R-C7 | GHCR push | `helm push` + Cosign sign |
-| R-C8 | GitHub Release created | `gh release create` |
-| R-C9 | Release branch updated | Push to `release` branch |
+| ID   | Control                      | Code Location                     |
+| ---- | ---------------------------- | --------------------------------- |
+| R-C1 | Trigger on main push         | `push.branches: [main]`           |
+| R-C2 | Only process charts/\*\*     | `paths: ['charts/**']`            |
+| R-C3 | Tag doesn't already exist    | `git rev-parse "$TAG_NAME"` check |
+| R-C4 | Tag points to correct commit | Compare existing tag SHA          |
+| R-C5 | Chart.yaml has version       | `VERSION=$(grep '^version:')`     |
+| R-C6 | Package attestation          | `attest-build-provenance`         |
+| R-C7 | GHCR push                    | `helm push` + Cosign sign         |
+| R-C8 | GitHub Release created       | `gh release create`               |
+| R-C9 | Release branch updated       | Push to `release` branch          |
 
 #### Test Matrix
 
-| Test ID | Control | Scenario | Expected | Cleanup |
-|---------|---------|----------|----------|---------|
-| R-T1 | R-C1 | Push to integration (not main) | Workflow doesn't run | N/A |
-| R-T2 | R-C2 | Push to main (non-chart files) | Workflow doesn't run | N/A |
-| R-T3 | R-C3 | Tag already exists (same commit) | Skip with notice | N/A |
-| R-T4 | R-C4 | Tag exists at different commit | Error - version not bumped | Investigate |
-| R-T5 | R-C5 | Chart.yaml missing version | Error extracting version | Fix Chart.yaml |
-| R-T6 | R-C6 | Package created | Attestation generated | Verify attestation |
-| R-T7 | R-C7 | GHCR push | Chart in registry + signed | Verify with cosign |
-| R-T8 | R-C8 | Release created | GitHub Release exists | Verify assets |
-| R-T9 | R-C9 | Release branch updated | index.yaml updated | Verify content |
+| Test ID | Control | Scenario                         | Expected                   | Cleanup            |
+| ------- | ------- | -------------------------------- | -------------------------- | ------------------ |
+| R-T1    | R-C1    | Push to integration (not main)   | Workflow doesn't run       | N/A                |
+| R-T2    | R-C2    | Push to main (non-chart files)   | Workflow doesn't run       | N/A                |
+| R-T3    | R-C3    | Tag already exists (same commit) | Skip with notice           | N/A                |
+| R-T4    | R-C4    | Tag exists at different commit   | Error - version not bumped | Investigate        |
+| R-T5    | R-C5    | Chart.yaml missing version       | Error extracting version   | Fix Chart.yaml     |
+| R-T6    | R-C6    | Package created                  | Attestation generated      | Verify attestation |
+| R-T7    | R-C7    | GHCR push                        | Chart in registry + signed | Verify with cosign |
+| R-T8    | R-C8    | Release created                  | GitHub Release exists      | Verify assets      |
+| R-T9    | R-C9    | Release branch updated           | index.yaml updated         | Verify content     |
+
+---
+
+### Attestation and Provenance (`release-atomic-chart.yaml`)
+
+#### Controls
+
+| ID    | Control                          | Code Location                                    |
+| ----- | -------------------------------- | ------------------------------------------------ |
+| AT-C1 | Package attestation generated    | `attest-build-provenance` action                 |
+| AT-C2 | Attestation attached to artifact | `--subject-path` pointing to package             |
+| AT-C3 | Cosign signature on OCI          | `cosign sign` with OIDC                          |
+| AT-C4 | Attestation verifiable           | `gh attestation verify` succeeds                 |
+| AT-C5 | Cosign signature verifiable      | `cosign verify` succeeds                         |
+| AT-C6 | Attestation includes build info  | Contains workflow, commit SHA, repository        |
+
+#### Test Matrix
+
+| Test ID | Control | Scenario                            | Expected                                   | Verification                              |
+| ------- | ------- | ----------------------------------- | ------------------------------------------ | ----------------------------------------- |
+| AT-T1   | AT-C1   | Release workflow completes          | Attestation step succeeds                  | Check workflow logs                       |
+| AT-T2   | AT-C2   | Package has attestation             | Attestation linked to .tgz artifact        | `gh attestation verify <package>`         |
+| AT-T3   | AT-C3   | OCI image has Cosign signature      | Signature exists in registry               | `cosign tree ghcr.io/.../chart`           |
+| AT-T4   | AT-C4   | Verify package attestation          | Returns valid attestation JSON             | `gh attestation verify --format json`     |
+| AT-T5   | AT-C5   | Verify Cosign signature             | Verification succeeds with OIDC issuer     | `cosign verify --certificate-oidc-issuer` |
+| AT-T6   | AT-C6   | Attestation contains build metadata | Includes repo, workflow, SHA, actor        | Parse attestation JSON                    |
+| AT-T7   | AT-C4   | Tampered package fails verification | Attestation verify fails                   | Modify .tgz, run verify                   |
+| AT-T8   | AT-C5   | Wrong issuer fails verification     | Cosign verify fails                        | Use wrong `--certificate-oidc-issuer`     |
+
+#### Attestation Lineage Tests
+
+These tests verify the complete chain of trust through the pipeline.
+
+| Test ID | Scenario                           | Expected                                          | Verification                                         |
+| ------- | ---------------------------------- | ------------------------------------------------- | ---------------------------------------------------- |
+| AL-T1   | Trace release to merge commit      | Release attestation references merge commit SHA   | Compare attestation SHA with `git log main`          |
+| AL-T2   | Trace merge to atomic PR           | Merge commit matches PR merge SHA                 | `gh pr view --json mergeCommit`                      |
+| AL-T3   | Trace atomic PR to integration     | PR source branch created from integration commit  | `git log charts/<chart>..integration`                |
+| AL-T4   | Trace integration to contributor   | Integration commit from merged contribution PR    | `git log integration --oneline`                      |
+| AL-T5   | Full lineage audit                 | Can trace release back to original contributor PR | Chain: Release → main → PR → charts/* → integration  |
+| AL-T6   | Attestation actor matches workflow | `github-actions[bot]` or workflow actor in claims | Parse attestation `predicate.invocation.actor`       |
+
+#### Verification Commands Reference
+
+```bash
+# Verify GitHub attestation on package
+gh attestation verify charts/test-workflow-0.2.0.tgz \
+  --repo aRustyDev/helm-charts
+
+# Verify with JSON output for detailed inspection
+gh attestation verify charts/test-workflow-0.2.0.tgz \
+  --repo aRustyDev/helm-charts \
+  --format json | jq '.attestations[].verificationResult'
+
+# Verify Cosign signature on OCI image
+cosign verify ghcr.io/arustydev/helm-charts/test-workflow:0.2.0 \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "github.com/aRustyDev/helm-charts"
+
+# View Cosign signature tree
+cosign tree ghcr.io/arustydev/helm-charts/test-workflow:0.2.0
+
+# Extract attestation predicate for lineage verification
+gh attestation verify charts/test-workflow-0.2.0.tgz \
+  --repo aRustyDev/helm-charts \
+  --format json | jq '.attestations[0].bundle.dsseEnvelope.payload' | \
+  base64 -d | jq '.predicate'
+```
 
 ---
 
@@ -187,6 +255,7 @@ appVersion: "1.0.0"
 **Objective**: Verify complete workflow from contribution to release.
 
 **Steps**:
+
 1. Create feature branch from `integration`
 2. Add minor feature to `charts/test-workflow` (bump minor)
 3. Commit with `feat(test-workflow): add test feature` (signed)
@@ -200,12 +269,31 @@ appVersion: "1.0.0"
 11. Verify Release workflow creates tag + publishes
 
 **Expected**:
+
 - Version bumped from 0.1.0 → 0.2.0
 - Tag `test-workflow-v0.2.0` created
-- Package in GHCR
-- GitHub Release created
+- Package in GHCR with Cosign signature
+- GitHub Release created with attestation
+- Attestation verifiable via `gh attestation verify`
+
+**Post-Release Verification**:
+
+```bash
+# Verify GitHub attestation
+gh attestation verify <release-asset>.tgz --repo aRustyDev/helm-charts
+
+# Verify Cosign signature
+cosign verify ghcr.io/arustydev/helm-charts/test-workflow:0.2.0 \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# Verify lineage (attestation contains correct commit SHA)
+gh attestation verify <release-asset>.tgz --repo aRustyDev/helm-charts --format json | \
+  jq '.attestations[0].bundle.dsseEnvelope.payload' | base64 -d | \
+  jq '.predicate.invocation.configSource.digest.sha1'
+```
 
 **Cleanup**:
+
 - Delete `charts/test-workflow` branch
 - Keep tag and release (document in test log)
 
@@ -216,6 +304,7 @@ appVersion: "1.0.0"
 **Objective**: Verify untrusted contributors require manual review at integration.
 
 **Steps**:
+
 1. Fork repo as untrusted user
 2. Create same feature change
 3. Create PR from fork to `integration`
@@ -225,11 +314,13 @@ appVersion: "1.0.0"
 7. Verify rest of pipeline works normally
 
 **Expected**:
+
 - Auto-merge skipped
 - Manual merge works
 - W2 → W5 → Release functions normally
 
 **Cleanup**:
+
 - Close PR if not merged
 - Delete any test branches
 
@@ -240,6 +331,7 @@ appVersion: "1.0.0"
 **Objective**: Verify unsigned commits require manual review.
 
 **Steps**:
+
 1. Create feature branch
 2. Commit with `--no-gpg-sign`
 3. Create PR to `integration`
@@ -249,10 +341,12 @@ appVersion: "1.0.0"
 7. Verify rest of pipeline works
 
 **Expected**:
+
 - Auto-merge skipped due to unverified commits
 - Pipeline continues after manual merge
 
 **Cleanup**:
+
 - Delete test branches
 
 ---
@@ -262,6 +356,7 @@ appVersion: "1.0.0"
 **Objective**: Verify multiple charts are processed independently.
 
 **Steps**:
+
 1. Change both `charts/test-workflow` and `charts/cloudflared`
 2. Merge to `integration`
 3. Verify W2 creates TWO branches and TWO PRs
@@ -270,13 +365,289 @@ appVersion: "1.0.0"
 6. Verify Release creates separate tags/releases
 
 **Expected**:
+
 - Two independent pipelines
 - Each chart versioned separately
 - Each chart released separately
 
 **Cleanup**:
+
 - Delete test branches
 - Revert test changes if needed
+
+---
+
+### E2E-5: Missing Attestation Map Blocks Release
+
+**Objective**: Verify that releases cannot proceed without valid attestation maps.
+
+**Scenario**: A PR is merged to main that bypasses W5 validation (e.g., manually created PR without going through W2).
+
+**Steps**:
+
+1. Create `charts/test-workflow` branch directly from main (bypassing integration/W2)
+2. Make a chart change with version bump
+3. Create PR to main from this branch
+4. PR passes W5 lint tests but has no attestation map (wasn't created by W2)
+5. Attempt to merge and observe release workflow
+
+**Expected**:
+
+- W5 validation jobs run and pass
+- PR description has NO `<!-- W5_ATTESTATION_MAP -->` section
+- Release workflow runs but logs warning about missing attestation data
+- Release proceeds BUT tag annotation shows "No attestation data available"
+- Future improvement: Block release if attestation map missing
+
+**Current Behavior** (documents gap):
+
+- Release currently proceeds without attestation map
+- This is a known limitation documented in [Limitations](./docs/src/attestation/limitations.md)
+
+**Cleanup**:
+
+- Delete test branch
+- Delete tag if created
+- Delete release if created
+
+---
+
+### E2E-6: K8s Test Failure Blocks Release
+
+**Objective**: Verify that a K8s test failure in W5 prevents the chart from being released.
+
+**Steps**:
+
+1. Create chart change that passes lint but fails install tests
+   ```yaml
+   # Example: Invalid resource that passes lint but fails install
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: {{ .Release.Name }}-test
+   data:
+     key: {{ required "value is required" .Values.nonexistent }}
+   ```
+2. Merge to integration (W1 passes, only lint checks)
+3. W2 creates atomic PR to main
+4. W5 runs: lint passes, K8s matrix tests FAIL
+5. PR cannot merge (required checks fail)
+
+**Expected**:
+
+- W5 k8s-test jobs fail
+- Required status checks block merge
+- No release is created
+- Attestation map shows test failures
+
+**Verification**:
+
+```bash
+# Check PR status
+gh pr view <pr-number> --json statusCheckRollup --jq '.statusCheckRollup[] | select(.conclusion != "SUCCESS")'
+
+# Verify no tag was created
+git tag -l "test-workflow-*" | tail -1
+```
+
+**Cleanup**:
+
+- Fix the chart or close PR
+- Delete test branches
+
+---
+
+### E2E-7: Lint Failure Blocks Release
+
+**Objective**: Verify that lint failures in W5 prevent release.
+
+**Steps**:
+
+1. Create chart change with lint errors (but valid YAML)
+   ```yaml
+   # Missing required Chart.yaml fields
+   apiVersion: v2
+   name: test-workflow
+   # Missing: version, description
+   ```
+2. Merge to integration
+3. W2 creates atomic PR
+4. W5 runs: ArtifactHub lint or ct lint FAIL
+5. PR cannot merge
+
+**Expected**:
+
+- artifacthub-lint or helm-lint jobs fail
+- Required status checks block merge
+- No release is created
+
+**Cleanup**:
+
+- Fix chart or close PR
+- Delete test branches
+
+---
+
+### E2E-8: Version Bump Failure Blocks Release
+
+**Objective**: Verify that if version bump fails, the release has appropriate handling.
+
+**Steps**:
+
+1. Create chart change with invalid conventional commit
+   ```
+   "update something"  # Not conventional commit format
+   ```
+2. Merge to integration
+3. W2 creates atomic PR
+4. W5 runs: version-bump determines no bump needed (non-conventional)
+5. If Chart.yaml version already exists as tag...
+
+**Expected**:
+
+- Version bump job logs "no version bump needed" or determines bump type
+- If tag already exists at different commit → Release workflow errors
+- Release workflow checks for tag collision before creating
+
+**Verification**:
+
+```bash
+# Check if tag exists at different commit
+TAG="test-workflow-v0.1.0"
+EXISTING=$(git rev-list -n 1 "$TAG" 2>/dev/null || echo "none")
+CURRENT="${{ github.sha }}"
+if [[ "$EXISTING" != "none" && "$EXISTING" != "$CURRENT" ]]; then
+  echo "ERROR: Tag exists at different commit!"
+fi
+```
+
+**Cleanup**:
+
+- Close PR if test-only
+- Delete test branches
+
+---
+
+### E2E-9: Attestation Verification Failure Detection
+
+**Objective**: Verify that consumers can detect attestation verification failures.
+
+**Steps**:
+
+1. Complete E2E-1 to create a valid release
+2. Download the released package
+3. Modify the package (simulate tampering)
+4. Attempt to verify the tampered package
+
+**Expected**:
+
+- `gh attestation verify` fails on tampered package
+- `cosign verify` fails on modified OCI image
+- Error message clearly indicates verification failure
+
+**Verification Commands**:
+
+```bash
+# Download valid package
+gh release download test-workflow-v0.2.0 \
+  --repo aRustyDev/helm-charts \
+  --pattern "test-workflow-0.2.0.tgz"
+
+# Verify original (should pass)
+gh attestation verify test-workflow-0.2.0.tgz --repo aRustyDev/helm-charts
+echo "Original verification: PASSED"
+
+# Tamper with package
+cp test-workflow-0.2.0.tgz test-workflow-0.2.0-tampered.tgz
+echo "malicious" >> test-workflow-0.2.0-tampered.tgz
+
+# Verify tampered (should fail)
+if gh attestation verify test-workflow-0.2.0-tampered.tgz --repo aRustyDev/helm-charts 2>&1; then
+  echo "ERROR: Tampered package verified (unexpected)"
+  exit 1
+else
+  echo "Tampered verification: CORRECTLY FAILED"
+fi
+```
+
+**Cleanup**:
+
+- Remove downloaded test files
+
+---
+
+### E2E-10: Full Lineage Trace Verification
+
+**Objective**: Verify complete lineage can be traced from release to original contributor.
+
+**Steps**:
+
+1. Complete E2E-1 with a trusted contributor
+2. After release, perform full lineage trace
+3. Verify each link in the chain
+
+**Verification Script**:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHART="test-workflow"
+VERSION="0.2.0"
+TAG="${CHART}-v${VERSION}"
+REPO="aRustyDev/helm-charts"
+
+echo "=== Full Lineage Trace for $TAG ==="
+
+# Step 1: Get release commit
+echo "1. Getting release commit..."
+RELEASE_SHA=$(gh api "/repos/${REPO}/git/ref/tags/${TAG}" --jq '.object.sha')
+echo "   Release SHA: $RELEASE_SHA"
+
+# Step 2: Find merge PR
+echo "2. Finding merge PR..."
+MERGE_PR=$(gh api "/repos/${REPO}/commits/${RELEASE_SHA}/pulls" --jq '.[0].number')
+echo "   Merge PR: #$MERGE_PR"
+
+# Step 3: Get PR source branch
+echo "3. Getting PR source branch..."
+SOURCE_BRANCH=$(gh pr view "$MERGE_PR" --repo "$REPO" --json headRefName -q '.headRefName')
+echo "   Source branch: $SOURCE_BRANCH"
+
+# Step 4: Extract attestation map
+echo "4. Extracting attestation map..."
+ATTESTATION=$(gh pr view "$MERGE_PR" --repo "$REPO" --json body -q '.body' | grep -A5 "W5_ATTESTATION_MAP" || echo "Not found")
+if [[ "$ATTESTATION" != "Not found" ]]; then
+  echo "   Attestation map: PRESENT"
+else
+  echo "   Attestation map: MISSING (gap in lineage)"
+fi
+
+# Step 5: Verify Cosign signature
+echo "5. Verifying Cosign signature..."
+if cosign verify "ghcr.io/arustydev/helm-charts/${CHART}:${VERSION}" \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-identity-regexp "github.com/aRustyDev/helm-charts" \
+    --output text 2>/dev/null; then
+  echo "   Cosign: VALID"
+else
+  echo "   Cosign: INVALID"
+fi
+
+echo ""
+echo "=== Lineage Trace Complete ==="
+```
+
+**Expected**:
+
+- All 5 steps complete successfully
+- Each link in chain verifiable
+- Attestation map present in merge PR
+- Cosign signature valid
+
+**Cleanup**:
+
+- None (uses existing release from E2E-1)
 
 ---
 
@@ -285,11 +656,13 @@ appVersion: "1.0.0"
 ### After Each Test
 
 1. **Delete test branches**:
+
    ```bash
    git push origin --delete <branch-name>
    ```
 
 2. **Close test PRs**:
+
    ```bash
    gh pr close <PR-number> --delete-branch
    ```
@@ -301,39 +674,42 @@ appVersion: "1.0.0"
 
 ### Artifacts to Preserve in Version Control
 
-| Artifact | Keep? | Reason |
-|----------|-------|--------|
-| Test chart (`charts/test-workflow/`) | NO | Remove after testing |
-| Test results documentation | YES | Add to `docs/testing/` |
-| Workflow fixes discovered | YES | Commit improvements |
-| This test plan | YES | Reference for future testing |
+| Artifact                             | Keep? | Reason                       |
+| ------------------------------------ | ----- | ---------------------------- |
+| Test chart (`charts/test-workflow/`) | NO    | Remove after testing         |
+| Test results documentation           | YES   | Add to `docs/testing/`       |
+| Workflow fixes discovered            | YES   | Commit improvements          |
+| This test plan                       | YES   | Reference for future testing |
 
 ### Artifacts to Remove
 
-| Artifact | How to Remove |
-|----------|---------------|
-| Test branches | `git push origin --delete <branch>` |
-| Test PRs | `gh pr close --delete-branch` |
-| Test tags | `git push origin --delete <tag>` (if test-only) |
-| Test releases | Delete via GitHub UI (if test-only) |
-| Test chart | `rm -rf charts/test-workflow && git commit` |
+| Artifact      | How to Remove                                   |
+| ------------- | ----------------------------------------------- |
+| Test branches | `git push origin --delete <branch>`             |
+| Test PRs      | `gh pr close --delete-branch`                   |
+| Test tags     | `git push origin --delete <tag>` (if test-only) |
+| Test releases | Delete via GitHub UI (if test-only)             |
+| Test chart    | `rm -rf charts/test-workflow && git commit`     |
 
 ---
 
 ## Test Execution Checklist
 
 ### Phase 1: Auto-Merge Tests
+
 - [ ] AM-T1: W1 failure prevents trigger
 - [ ] AM-T5: Untrusted author blocked
 - [ ] AM-T7: Unsigned commits blocked
 - [ ] AM-T9: Happy path works
 
 ### Phase 2: W2 Tests
+
 - [ ] W2-T1: Path filtering works
 - [ ] W2-T5: Single chart creates branch/PR
 - [ ] W2-T6: Multiple charts handled
 
 ### Phase 3: W5 Tests
+
 - [ ] W5-T4: Invalid branch pattern rejected
 - [ ] W5-T5: Valid branch accepted
 - [ ] W5-T10: Patch version bump
@@ -341,15 +717,33 @@ appVersion: "1.0.0"
 - [ ] W5-T13: Cleanup on merge
 
 ### Phase 4: Release Tests
+
 - [ ] R-T3: Duplicate tag handling
 - [ ] R-T7: GHCR push + signing
 - [ ] R-T8: GitHub Release created
 
-### Phase 5: End-to-End
+### Phase 5: Attestation Tests
+
+- [ ] AT-T2: Package has attestation
+- [ ] AT-T4: Verify package attestation
+- [ ] AT-T5: Verify Cosign signature
+- [ ] AT-T6: Attestation contains build metadata
+- [ ] AT-T7: Tampered package fails verification
+- [ ] AL-T1: Trace release to merge commit
+- [ ] AL-T5: Full lineage audit
+
+### Phase 6: End-to-End
+
 - [ ] E2E-1: Happy path complete
 - [ ] E2E-2: Untrusted user flow
 - [ ] E2E-3: Unsigned commit flow
 - [ ] E2E-4: Multiple charts
+- [ ] E2E-5: Missing attestation map handling
+- [ ] E2E-6: K8s test failure blocks release
+- [ ] E2E-7: Lint failure blocks release
+- [ ] E2E-8: Version bump failure handling
+- [ ] E2E-9: Attestation verification failure detection
+- [ ] E2E-10: Full lineage trace verification
 
 ---
 
@@ -358,6 +752,7 @@ appVersion: "1.0.0"
 ### Test Order Dependencies
 
 Some tests must run in sequence:
+
 1. AM tests should complete before E2E tests
 2. W2 tests require integration branch access
 3. W5 tests require W2 to create the PR first
@@ -366,6 +761,7 @@ Some tests must run in sequence:
 ### Test Isolation
 
 To avoid interference:
+
 - Use unique chart names for parallel tests
 - Use unique branch names with test ID prefix
 - Clean up immediately after each test
@@ -373,6 +769,7 @@ To avoid interference:
 ### Failure Investigation
 
 When a test fails:
+
 1. Check workflow run logs
 2. Check branch protection rules
 3. Check repository variables

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -38,6 +38,10 @@
 # Security
 
 - [Chart Verification](./security/verification.md)
+- [Attestation & Provenance](./attestation/index.md)
+  - [Verification Methods](./attestation/verification.md)
+  - [Lineage Tracing](./attestation/lineage.md)
+  - [Limitations](./attestation/limitations.md)
 
 # Contributing
 

--- a/docs/src/attestation/index.md
+++ b/docs/src/attestation/index.md
@@ -1,0 +1,136 @@
+# Attestation and Provenance
+
+This section documents how attestations provide cryptographic proof of provenance for Helm charts released from this repository.
+
+## What Are Attestations?
+
+Attestations are cryptographically signed statements that bind metadata about how an artifact was built to the artifact itself. They answer the question: **"How was this artifact created, and by whom?"**
+
+In this repository, attestations serve three purposes:
+
+1. **Build Provenance**: Prove that a chart package was built by our GitHub Actions workflows
+2. **Verification Chain**: Link each release back through the validation pipeline
+3. **Tamper Detection**: Detect if an artifact has been modified after signing
+
+## Attestation Types Used
+
+| Type | What It Proves | Where Generated |
+|------|----------------|-----------------|
+| **Build Provenance** | Package was built from this repo's workflows | Release workflow (W8) |
+| **K8s Test Attestation** | Chart passed install tests on specific K8s versions | W5 validation |
+| **Cosign Signature** | OCI image came from our workflow and hasn't changed | Release workflow |
+| **Attestation Map** | Links PR to all upstream validation attestations | W5 → Release |
+
+## How Attestations Flow Through the Pipeline
+
+```
+Developer PR → W1 (Validate) → integration merge
+                                    ↓
+                              W2 (Create atomic PR)
+                                    ↓
+                              W5 (Validate) ──────────────────┐
+                              │ - lint tests                  │
+                              │ - ArtifactHub lint            │
+                              │ - K8s matrix tests ─────→ Test Attestations
+                              │ - version bump               │
+                              └────────────────────────────────┤
+                                    ↓                         │
+                              PR Description updated with     │
+                              ATTESTATION_MAP (JSON)         │
+                                    ↓                         │
+                              Merge to main                   │
+                                    ↓                         │
+                              Release (W8) ←─────────────────┘
+                              │ - Extract attestation map from source PR
+                              │ - Create tag with lineage metadata
+                              │ - Package chart
+                              │ - Generate build attestation
+                              │ - Sign with Cosign
+                              │ - Create GitHub Release
+                              └─→ Published artifact with full provenance
+```
+
+## Verification Capabilities
+
+### Quick Verification (One Command)
+
+For most users, a single command verifies the chart came from this repository:
+
+```bash
+# Verify GHCR chart
+cosign verify ghcr.io/arustydev/helm-charts/cloudflared:1.0.0 \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "github.com/aRustyDev/helm-charts"
+
+# Verify GitHub Release package
+gh attestation verify cloudflared-1.0.0.tgz --repo aRustyDev/helm-charts
+```
+
+### Deep Verification (Full Lineage)
+
+For security-critical deployments, trace the complete provenance chain:
+
+1. **Verify the package attestation** - proves it was built by our workflow
+2. **Extract source PR from release** - identifies which PR created the release
+3. **Verify the attestation map** - confirms all tests passed
+4. **Trace to integration merge** - links back to contributor PR
+
+See [Lineage Tracing](./lineage.md) for detailed commands.
+
+## Confidence Levels
+
+| Verification Level | What You Know | Confidence |
+|--------------------|---------------|------------|
+| Cosign signature valid | Artifact came from our GitHub Actions | High |
+| Build attestation valid | Package built from tagged commit in our repo | High |
+| Attestation map present | Upstream tests passed (recorded in PR) | Medium |
+| Full lineage trace | Complete chain from contributor to release | Very High |
+
+## Documentation Structure
+
+- **[Verification](./verification.md)**: Commands and methods for verifying charts
+- **[Lineage Tracing](./lineage.md)**: How to trace provenance through the pipeline
+- **[Limitations](./limitations.md)**: What attestations don't prove
+
+## Quick Reference
+
+### Distribution Channels
+
+| Channel | Attestation Type | Verification Command |
+|---------|------------------|---------------------|
+| GHCR (OCI) | Cosign signature + Build attestation | `cosign verify` |
+| GitHub Release | Build attestation + .sig file | `gh attestation verify` |
+| charts.arusty.dev | None (index.yaml points to GH Release) | Download from Release, then verify |
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `.github/scripts/attestation-lib.sh` | Shared library for attestation operations |
+| `.github/workflows/release-atomic-chart.yaml` | Generates build attestations and Cosign signatures |
+| `.github/workflows/validate-atomic-chart-pr.yaml` | Generates test attestations and attestation map |
+
+## Security Model
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    WHAT ATTESTATIONS PROVE                       │
+├─────────────────────────────────────────────────────────────────┤
+│ ✓ This artifact was built by GitHub Actions in this repo        │
+│ ✓ The build used this specific commit SHA                       │
+│ ✓ The workflow that built it was release-atomic-chart.yaml      │
+│ ✓ The artifact has not been tampered with since signing         │
+│ ✓ (With lineage) All upstream tests passed                      │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│                 WHAT ATTESTATIONS DON'T PROVE                    │
+├─────────────────────────────────────────────────────────────────┤
+│ ✗ The source code is free of vulnerabilities                    │
+│ ✗ The chart follows security best practices                     │
+│ ✗ The upstream images referenced are safe                       │
+│ ✗ The contributor's identity beyond their GitHub account        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+See [Limitations](./limitations.md) for detailed discussion.

--- a/docs/src/attestation/limitations.md
+++ b/docs/src/attestation/limitations.md
@@ -1,0 +1,252 @@
+# Limitations
+
+Attestations provide strong guarantees about *how* an artifact was built, but they have important limitations. Understanding what attestations do NOT prove is essential for a complete security posture.
+
+## What Attestations Are NOT
+
+### Not a Security Audit
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  ATTESTATION ≠ SECURITY AUDIT                                           │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Attestation proves:                                                    │
+│    "This chart was built by GitHub Actions from commit abc123"          │
+│                                                                         │
+│  Attestation does NOT prove:                                            │
+│    "This chart is secure and free of vulnerabilities"                   │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+A valid attestation means the build process was trusted. It says nothing about whether the source code itself is safe.
+
+### Not a Vulnerability Scan
+
+Attestations do not scan for:
+- CVEs in the chart templates
+- Insecure default configurations
+- Vulnerable base images referenced in values.yaml
+- Hardcoded secrets or credentials
+- RBAC misconfigurations
+
+**You should still run**:
+```bash
+# Scan for vulnerabilities
+trivy config charts/cloudflared/
+grype charts/cloudflared/
+
+# Check for misconfigurations
+kubescape scan charts/cloudflared/
+checkov -d charts/cloudflared/
+```
+
+### Not a Code Review
+
+Attestations prove the workflow ran, but they don't prove:
+- Code was reviewed by a human (for non-main branches)
+- Business logic is correct
+- Best practices were followed
+- The change does what the commit message claims
+
+### Not an Identity Verification
+
+GitHub attestations verify the *GitHub account*, not the person behind it:
+
+| What We Know | What We Don't Know |
+|--------------|-------------------|
+| GitHub user `@contributor` committed this | Who controls that account |
+| Commits were signed with their GPG/SSH key | If their key was compromised |
+| They're listed in CODEOWNERS (for auto-merge) | Their real-world identity |
+
+### Not Runtime Security
+
+Attestations cover build-time only:
+
+```
+                    ATTESTATION COVERAGE
+                    ════════════════════
+
+  Source Code ──→ Build ──→ Package ──→ Deploy ──→ Runtime
+       │            │          │           │          │
+       │      [ATTESTED]  [ATTESTED]       │          │
+       │            │          │           │          │
+       ▼            ▼          ▼           ▼          ▼
+    Unknown     Verified    Verified   Unknown    Unknown
+```
+
+What happens after deployment is outside attestation scope:
+- Container behavior at runtime
+- Network connections made
+- Data accessed or exfiltrated
+- Resource consumption
+
+## Not Possible with Current Implementation
+
+### Verifying Upstream Images
+
+If a chart's `values.yaml` references:
+```yaml
+image:
+  repository: nginx
+  tag: "1.25"
+```
+
+The attestation proves the *chart template* came from our repo, but NOT that:
+- The nginx image is legitimate
+- The image tag hasn't been changed since we tested
+- The image is free of vulnerabilities
+
+**Mitigation**: Pin images by digest in your values:
+```yaml
+image:
+  repository: nginx@sha256:abc123...
+```
+
+### Proving Source Code Wasn't Malicious
+
+A sophisticated attacker could:
+1. Compromise a trusted contributor's GitHub account
+2. Submit malicious code with valid GPG signatures
+3. The code passes linting (syntax is valid)
+4. Tests pass (malicious code activates only in prod)
+5. Attestation is generated - everything looks legitimate
+
+The attestation proves the *process* was followed, not that the *code* is safe.
+
+### Proving Dependencies Are Safe
+
+Charts may have dependencies in `Chart.yaml`:
+```yaml
+dependencies:
+  - name: common
+    version: "1.x.x"
+    repository: "https://charts.bitnami.com/bitnami"
+```
+
+Attestations don't verify:
+- The external repository is trustworthy
+- The dependency hasn't been compromised
+- Transitive dependencies are safe
+
+### Verifying Helm Repository Index
+
+The `index.yaml` at `charts.arusty.dev` is NOT signed. It's served from the `release` branch.
+
+Attack vector:
+1. Attacker gains write access to `release` branch
+2. Modifies `index.yaml` to point to malicious packages
+3. Users who `helm install` without verification get bad charts
+
+**Mitigation**: Always verify after download:
+```bash
+helm pull arustydev/cloudflared
+gh attestation verify cloudflared-*.tgz --repo aRustyDev/helm-charts
+helm install ... --verify  # Note: --verify uses provenance files, not attestations
+```
+
+## What Attestations Don't Cover
+
+| Aspect | Covered? | Details |
+|--------|----------|---------|
+| Build integrity | Yes | Package matches build output |
+| Build source | Yes | Built from specific commit |
+| Build environment | Yes | GitHub Actions runner |
+| Test execution | Yes | Tests ran (via attestation map) |
+| Test correctness | No | Tests might miss bugs |
+| Code security | No | No vulnerability scanning |
+| Business logic | No | No semantic verification |
+| Runtime behavior | No | Only build-time |
+| Upstream images | No | Referenced images not verified |
+| Dependencies | No | External chart repos not verified |
+| Future changes | No | Attestation is point-in-time |
+
+## The Trust Boundary
+
+```
+┌───────────────────────────────────────────────────────────────────────────┐
+│                           TRUST BOUNDARY                                   │
+├───────────────────────────────────────────────────────────────────────────┤
+│                                                                           │
+│   INSIDE (Attested)              │    OUTSIDE (Not Attested)              │
+│   ─────────────────              │    ──────────────────────              │
+│                                  │                                        │
+│   • This repository's code       │    • External chart dependencies       │
+│   • GitHub Actions workflows     │    • Referenced container images       │
+│   • Build process execution      │    • Helm repository index.yaml        │
+│   • Test execution (recorded)    │    • User-provided values              │
+│   • Package creation             │    • Deployment environment            │
+│   • Cosign signature             │    • Runtime behavior                  │
+│   • GitHub artifact attestation  │    • Network connections               │
+│                                  │    • Data handling                     │
+│                                  │                                        │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+## Recommendations for Complete Security
+
+### 1. Verify Attestations (What We Provide)
+
+```bash
+cosign verify ghcr.io/arustydev/helm-charts/cloudflared:1.0.0 \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "github.com/aRustyDev/helm-charts"
+```
+
+### 2. Scan for Vulnerabilities (What You Must Do)
+
+```bash
+# Scan chart templates
+trivy config charts/cloudflared/
+
+# Scan referenced images
+trivy image nginx:1.25
+
+# Check Kubernetes security
+kubescape scan charts/cloudflared/
+```
+
+### 3. Review Changes (For Critical Deployments)
+
+```bash
+# Get the source PR
+gh pr view <pr-number> --repo aRustyDev/helm-charts
+
+# Review the actual changes
+gh pr diff <pr-number> --repo aRustyDev/helm-charts
+```
+
+### 4. Pin Dependencies
+
+```yaml
+# In values.yaml - pin by digest
+image:
+  repository: nginx
+  digest: sha256:abc123...  # Instead of tag
+
+# In Chart.yaml - pin versions
+dependencies:
+  - name: common
+    version: "1.2.3"  # Exact version, not "1.x.x"
+```
+
+### 5. Use Admission Controllers
+
+Deploy verification at cluster level:
+- [Sigstore Policy Controller](https://docs.sigstore.dev/policy-controller/overview/)
+- [Kyverno](https://kyverno.io/docs/writing-policies/verify-images/)
+- [Connaisseur](https://github.com/sse-secure-systems/connaisseur)
+
+## Summary
+
+| Statement | True? |
+|-----------|-------|
+| "This chart was built by our GitHub Actions" | Yes |
+| "This chart passed our CI tests" | Yes |
+| "This chart is secure" | Not proven |
+| "This chart has no vulnerabilities" | Not proven |
+| "The referenced images are safe" | Not proven |
+| "The chart will behave correctly at runtime" | Not proven |
+
+**Attestations are necessary but not sufficient for security.** They should be part of a defense-in-depth strategy that includes vulnerability scanning, code review, runtime monitoring, and least-privilege deployment.

--- a/docs/src/attestation/lineage.md
+++ b/docs/src/attestation/lineage.md
@@ -1,0 +1,319 @@
+# Attestation Lineage
+
+Attestation lineage is the ability to trace a released artifact back through every stage of the CI/CD pipeline to its original source. This provides a complete chain of trust from contributor code to deployed artifact.
+
+## Why Lineage Matters
+
+A single signature proves *who signed* the artifact, but lineage proves *how it was validated*:
+
+| Question | Single Signature | Full Lineage |
+|----------|------------------|--------------|
+| Was this built by our CI? | Yes | Yes |
+| Did all tests pass? | Unknown | Yes |
+| Which K8s versions was it tested on? | Unknown | v1.32, v1.33, v1.34 |
+| Which PR introduced this change? | Unknown | PR #123 |
+| Who was the original contributor? | Unknown | @contributor |
+| Was the PR auto-merged or reviewed? | Unknown | Auto-merged (trusted) |
+
+## The Provenance Chain
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                      COMPLETE PROVENANCE CHAIN                          │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  [Contributor PR] ──merge──→ [integration]                              │
+│       │                            │                                    │
+│       │ Author: @contributor       │ W2 creates atomic PR               │
+│       │ Commits: signed            │                                    │
+│       ▼                            ▼                                    │
+│  [W1 Validation]              [Atomic Chart PR]                         │
+│       │                            │                                    │
+│       │ Lint: ✓                    │ Source: charts/cloudflared         │
+│       │ ArtifactHub: ✓             │ Target: main                       │
+│       │ Commits: ✓                 │                                    │
+│       ▼                            ▼                                    │
+│  [Auto-Merge]                 [W5 Validation]                           │
+│       │                            │                                    │
+│       │ Trusted: ✓                 ├──→ ArtifactHub lint                │
+│       │ Signed: ✓                  ├──→ Helm lint (ct lint)             │
+│       │                            ├──→ K8s v1.32 install ──→ [Test Attestation] │
+│       │                            ├──→ K8s v1.33 install ──→ [Test Attestation] │
+│       │                            ├──→ K8s v1.34 install ──→ [Test Attestation] │
+│       │                            └──→ Version bump + changelog        │
+│       │                                 │                               │
+│       │                                 ▼                               │
+│       │                         [ATTESTATION_MAP in PR]                 │
+│       │                                 │                               │
+│       │                                 │ JSON with test run IDs        │
+│       │                                 │                               │
+│       ▼                                 ▼                               │
+│  [integration merge]           [Merge to main]                          │
+│                                        │                                │
+│                                        ▼                                │
+│                               [Release Workflow (W8)]                   │
+│                                        │                                │
+│                                        ├──→ Extract attestation map     │
+│                                        ├──→ Create tag with lineage     │
+│                                        ├──→ Package chart               │
+│                                        ├──→ Generate build attestation  │
+│                                        ├──→ Sign with Cosign            │
+│                                        └──→ Create GitHub Release       │
+│                                             │                           │
+│                                             ▼                           │
+│                                    [RELEASED ARTIFACT]                  │
+│                                    with full provenance                 │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Tracing Lineage Step by Step
+
+### Step 1: Start with the Released Artifact
+
+```bash
+CHART="cloudflared"
+VERSION="1.0.0"
+TAG="${CHART}-v${VERSION}"
+
+# Get the release and its commit SHA
+RELEASE_INFO=$(gh release view "$TAG" --repo aRustyDev/helm-charts --json tagCommitish,body)
+RELEASE_SHA=$(echo "$RELEASE_INFO" | jq -r '.tagCommitish')
+
+echo "Release SHA: $RELEASE_SHA"
+```
+
+### Step 2: Find the Source PR
+
+```bash
+# Get the PR that was merged to create this commit
+PR_NUMBER=$(gh api "/repos/aRustyDev/helm-charts/commits/${RELEASE_SHA}/pulls" \
+  --jq '.[0].number')
+
+echo "Source PR: #$PR_NUMBER"
+```
+
+### Step 3: Extract the Attestation Map
+
+```bash
+# Get the attestation map from the PR description
+PR_BODY=$(gh pr view "$PR_NUMBER" --repo aRustyDev/helm-charts --json body -q '.body')
+
+# Extract the attestation map JSON
+ATTESTATION_MAP=$(echo "$PR_BODY" | awk '
+    /<!-- W5_ATTESTATION_MAP -->/,/<!-- \/W5_ATTESTATION_MAP -->/ {
+        if (/```json/) { getline; found=1 }
+        if (/```/ && found) { found=0; exit }
+        if (found) print
+    }
+')
+
+echo "Attestation Map:"
+echo "$ATTESTATION_MAP" | jq .
+```
+
+### Step 4: Verify Test Attestations
+
+```bash
+# Parse the attestation map and verify each test run
+W5_RUN_ID=$(echo "$ATTESTATION_MAP" | jq -r ".[\"$CHART\"].w5_run")
+
+echo "W5 Workflow Run: https://github.com/aRustyDev/helm-charts/actions/runs/${W5_RUN_ID}"
+
+# You can view the workflow run to see test results
+gh run view "$W5_RUN_ID" --repo aRustyDev/helm-charts
+```
+
+### Step 5: Trace to Integration Merge
+
+```bash
+# Get the charts/<chart> branch that was merged
+HEAD_REF=$(gh pr view "$PR_NUMBER" --repo aRustyDev/helm-charts --json headRefName -q '.headRefName')
+echo "Source branch: $HEAD_REF"
+
+# This branch was created by W2, which means it came from integration
+# Find the W2 run that created this branch
+W2_RUNS=$(gh run list \
+  --repo aRustyDev/helm-charts \
+  --workflow create-atomic-chart-pr.yaml \
+  --json databaseId,conclusion,headBranch \
+  --jq ".[] | select(.headBranch == \"$HEAD_REF\")")
+
+echo "W2 Workflow that created this PR:"
+echo "$W2_RUNS" | head -1
+```
+
+### Step 6: Trace to Contributor PR
+
+```bash
+# The W2 run was triggered by a merge to integration
+# Find the contributor PR that merged to integration
+INTEGRATION_SHA=$(gh pr view "$PR_NUMBER" --repo aRustyDev/helm-charts --json commits -q '.commits[0].oid')
+
+# Search for PRs that merged this commit to integration
+# (This requires checking git history or workflow logs)
+echo "To trace further, check the W2 workflow logs for the source commit"
+```
+
+## Automated Lineage Verification
+
+### Full Lineage Script
+
+```bash
+#!/usr/bin/env bash
+# verify-lineage.sh - Verify complete attestation lineage for a chart release
+
+set -euo pipefail
+
+CHART="${1:?Usage: verify-lineage.sh <chart> <version>}"
+VERSION="${2:?Usage: verify-lineage.sh <chart> <version>}"
+TAG="${CHART}-v${VERSION}"
+REPO="aRustyDev/helm-charts"
+
+echo "=== Verifying Lineage for $CHART v$VERSION ==="
+
+# Step 1: Verify the Cosign signature
+echo ""
+echo "Step 1: Verifying Cosign signature..."
+if cosign verify "ghcr.io/arustydev/helm-charts/${CHART}:${VERSION}" \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-identity-regexp "github.com/aRustyDev/helm-charts" \
+    --output text 2>/dev/null; then
+  echo "  ✓ Cosign signature valid"
+else
+  echo "  ✗ Cosign signature INVALID"
+  exit 1
+fi
+
+# Step 2: Get release info
+echo ""
+echo "Step 2: Getting release info..."
+RELEASE_SHA=$(gh api "/repos/${REPO}/git/ref/tags/${TAG}" --jq '.object.sha')
+echo "  Release SHA: $RELEASE_SHA"
+
+# Step 3: Find source PR
+echo ""
+echo "Step 3: Finding source PR..."
+PR_NUMBER=$(gh api "/repos/${REPO}/commits/${RELEASE_SHA}/pulls" --jq '.[0].number' 2>/dev/null || echo "")
+if [[ -n "$PR_NUMBER" ]]; then
+  echo "  Source PR: #$PR_NUMBER"
+  PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+  echo "  URL: $PR_URL"
+else
+  echo "  ✗ Could not find source PR"
+  exit 1
+fi
+
+# Step 4: Extract attestation map
+echo ""
+echo "Step 4: Extracting attestation map..."
+PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body -q '.body')
+
+if echo "$PR_BODY" | grep -q "W5_ATTESTATION_MAP"; then
+  echo "  ✓ Attestation map found in PR description"
+
+  # Extract and display
+  ATTESTATION_MAP=$(echo "$PR_BODY" | sed -n '/```json/,/```/p' | grep -v '```' | head -20)
+  echo "  Map contents:"
+  echo "$ATTESTATION_MAP" | sed 's/^/    /'
+else
+  echo "  ⚠ No attestation map in PR (may be older release)"
+fi
+
+# Step 5: Verify W5 workflow ran
+echo ""
+echo "Step 5: Verifying W5 validation..."
+W5_RUN=$(gh run list \
+  --repo "$REPO" \
+  --workflow validate-atomic-chart-pr.yaml \
+  --json databaseId,conclusion,event \
+  --jq ".[] | select(.conclusion == \"success\")" | head -1)
+
+if [[ -n "$W5_RUN" ]]; then
+  echo "  ✓ W5 validation completed successfully"
+else
+  echo "  ⚠ Could not verify W5 run (may need manual check)"
+fi
+
+echo ""
+echo "=== Lineage Verification Complete ==="
+echo ""
+echo "Summary:"
+echo "  Chart: $CHART v$VERSION"
+echo "  Release SHA: $RELEASE_SHA"
+echo "  Source PR: #$PR_NUMBER"
+echo "  Cosign: ✓ Valid"
+echo ""
+echo "Full lineage traceable from release back to contribution."
+```
+
+## Attestation Map Format
+
+The attestation map stored in PR descriptions follows this schema:
+
+```json
+{
+  "<chart-name>": {
+    "version": "<semver>",
+    "w5_run": "<workflow-run-id>",
+    "k8s_versions": ["v1.32.11", "v1.33.7", "v1.34.3"]
+  }
+}
+```
+
+Example:
+
+```json
+{
+  "cloudflared": {
+    "version": "1.2.0",
+    "w5_run": "12345678901",
+    "k8s_versions": ["v1.32.11", "v1.33.7", "v1.34.3"]
+  }
+}
+```
+
+## Tag Annotation Format
+
+Each release tag includes lineage metadata in its annotation:
+
+```
+Release: cloudflared v1.2.0
+
+Attestation Lineage:
+- cloudflared: {"version": "1.2.0", "w5_run": "12345678901", ...}
+
+Changelog:
+## [1.2.0] - 2025-01-15
+### Added
+- Support for priorityClassName
+
+Source PR: #123
+Commit: abc123def456...
+```
+
+View tag annotation:
+
+```bash
+git tag -v cloudflared-v1.2.0
+# or
+git show cloudflared-v1.2.0 --quiet
+```
+
+## Confidence Levels by Verification Depth
+
+| Verification Depth | Commands Used | Confidence | What You Know |
+|--------------------|---------------|------------|---------------|
+| Signature only | `cosign verify` | High | Artifact from our workflow |
+| + Attestation | `gh attestation verify` | High | Built at specific commit |
+| + Source PR | `gh pr view` | Higher | Tests passed, version bumped |
+| + Attestation map | Extract from PR body | Higher | Which K8s versions tested |
+| + W5 run logs | `gh run view` | Very High | Actual test output |
+| + Integration trace | Git history analysis | Highest | Original contributor PR |
+
+## Limitations of Lineage Tracing
+
+See [Limitations](./limitations.md) for what lineage does NOT prove:
+- Source code security
+- Upstream image safety
+- Runtime behavior

--- a/docs/src/attestation/verification.md
+++ b/docs/src/attestation/verification.md
@@ -1,0 +1,249 @@
+# Verification Methods
+
+This page documents how to verify Helm charts from each distribution channel.
+
+## Prerequisites
+
+Install verification tools:
+
+```bash
+# Cosign (for OCI signature verification)
+brew install cosign
+# or: go install github.com/sigstore/cosign/v2/cmd/cosign@latest
+
+# GitHub CLI (for attestation verification)
+brew install gh
+gh auth login
+```
+
+## Verification by Distribution Channel
+
+### GHCR (OCI Registry) - Recommended
+
+Charts at `oci://ghcr.io/arustydev/helm-charts/<chart>` have both Cosign signatures and build attestations.
+
+#### Quick Verify
+
+```bash
+CHART="cloudflared"
+VERSION="1.0.0"
+
+cosign verify "ghcr.io/arustydev/helm-charts/${CHART}:${VERSION}" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "github.com/aRustyDev/helm-charts"
+```
+
+#### Strict Verify (Specific Workflow)
+
+```bash
+cosign verify "ghcr.io/arustydev/helm-charts/${CHART}:${VERSION}" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity "https://github.com/aRustyDev/helm-charts/.github/workflows/release-atomic-chart.yaml@refs/heads/main"
+```
+
+#### View Signature Details
+
+```bash
+# See the signature tree (signatures, attestations, SBOMs)
+cosign tree "ghcr.io/arustydev/helm-charts/${CHART}:${VERSION}"
+
+# Extract detailed claims
+cosign verify "ghcr.io/arustydev/helm-charts/${CHART}:${VERSION}" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp ".*" \
+  -o json | jq '.[].optional'
+```
+
+#### What GHCR Verification Proves
+
+| Check | Confidence | Details |
+|-------|------------|---------|
+| Signature valid | High | Cryptographic proof artifact matches signer |
+| OIDC issuer matches | High | Signed by GitHub Actions (not local machine) |
+| Certificate identity matches | High | Signed by our specific workflow |
+| Rekor transparency log | High | Signature recorded publicly, auditable |
+
+### GitHub Releases
+
+Packages attached to GitHub Releases (`<chart>-<version>.tgz`) have build attestations.
+
+#### Quick Verify
+
+```bash
+CHART="cloudflared"
+VERSION="1.0.0"
+TAG="${CHART}-v${VERSION}"
+
+# Download package
+gh release download "$TAG" \
+  --repo aRustyDev/helm-charts \
+  --pattern "${CHART}-${VERSION}.tgz"
+
+# Verify attestation
+gh attestation verify "${CHART}-${VERSION}.tgz" \
+  --repo aRustyDev/helm-charts
+```
+
+#### Detailed Verification with JSON Output
+
+```bash
+gh attestation verify "${CHART}-${VERSION}.tgz" \
+  --repo aRustyDev/helm-charts \
+  --format json | jq '.attestations[].verificationResult'
+```
+
+#### Verify Blob Signature
+
+Each release also includes a Cosign blob signature (`.sig` file):
+
+```bash
+# Download signature
+gh release download "$TAG" \
+  --repo aRustyDev/helm-charts \
+  --pattern "${CHART}-${VERSION}.tgz.sig"
+
+# Verify using Cosign
+cosign verify-blob "${CHART}-${VERSION}.tgz" \
+  --signature "${CHART}-${VERSION}.tgz.sig" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "github.com/aRustyDev/helm-charts"
+```
+
+#### What GitHub Release Verification Proves
+
+| Check | Confidence | Details |
+|-------|------------|---------|
+| Attestation valid | High | Package matches attested digest |
+| Repository matches | High | Built in this repository |
+| Workflow recorded | High | Built by release-atomic-chart.yaml |
+| Commit SHA recorded | High | Can trace to exact source |
+
+### charts.arusty.dev (Helm Repository)
+
+The Helm repository at `https://charts.arusty.dev` serves an `index.yaml` that points to GitHub Releases.
+
+**Important**: The Helm repository itself does not provide attestations. Verification happens after download.
+
+#### Install and Verify
+
+```bash
+CHART="cloudflared"
+VERSION="1.0.0"
+
+# Add repo
+helm repo add arustydev https://charts.arusty.dev
+helm repo update
+
+# Pull chart (downloads .tgz)
+helm pull arustydev/${CHART} --version ${VERSION}
+
+# Verify the downloaded package against GitHub attestations
+gh attestation verify "${CHART}-${VERSION}.tgz" \
+  --repo aRustyDev/helm-charts
+```
+
+#### What charts.arusty.dev Verification Proves
+
+| Check | Confidence | Details |
+|-------|------------|---------|
+| Package matches index | Medium | SHA in index.yaml matches downloaded file |
+| After gh attestation verify | High | Same as GitHub Release verification |
+
+**Note**: The `index.yaml` file is served from the `release` branch and is not cryptographically signed. Trust comes from the GitHub Release attestation, not the Helm repository index.
+
+## Verification Comparison Table
+
+| Channel | Attestation Available | Verification Method | Confidence |
+|---------|----------------------|---------------------|------------|
+| GHCR (OCI) | Cosign + Build Provenance | `cosign verify` | Highest |
+| GitHub Release | Build Provenance + .sig | `gh attestation verify` | High |
+| charts.arusty.dev | None (via GH Release) | Download, then `gh attestation verify` | High* |
+
+*Requires extra step to download and verify
+
+## Automated Verification
+
+### CI/CD Pipeline Example
+
+```yaml
+- name: Verify and Install Chart
+  run: |
+    CHART="cloudflared"
+    VERSION="1.0.0"
+
+    # Verify before install
+    cosign verify "ghcr.io/arustydev/helm-charts/${CHART}:${VERSION}" \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      --certificate-identity-regexp "github.com/aRustyDev/helm-charts"
+
+    # Install from verified OCI registry
+    helm install my-release "oci://ghcr.io/arustydev/helm-charts/${CHART}" \
+      --version "${VERSION}"
+```
+
+### Kubernetes Admission Policy (Kyverno)
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-helm-charts
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    - name: verify-signature
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      verifyImages:
+        - imageReferences:
+            - "ghcr.io/arustydev/helm-charts/*"
+          attestors:
+            - entries:
+                - keyless:
+                    issuer: "https://token.actions.githubusercontent.com"
+                    subjectRegExp: ".*github.com/aRustyDev/helm-charts.*"
+```
+
+## Troubleshooting
+
+### "no matching signatures" Error
+
+```bash
+# Check if signatures exist
+cosign tree ghcr.io/arustydev/helm-charts/cloudflared:1.0.0
+
+# Verify with relaxed identity (for debugging)
+cosign verify ghcr.io/arustydev/helm-charts/cloudflared:1.0.0 \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp ".*"
+```
+
+### Attestation Not Found
+
+```bash
+# List available attestations
+gh api "/repos/aRustyDev/helm-charts/attestations" \
+  --jq '.attestations | map(.bundle.dsseEnvelope.payloadType)'
+
+# Check release assets
+gh release view cloudflared-v1.0.0 --repo aRustyDev/helm-charts
+```
+
+### Wrong Version Tag
+
+```bash
+# List available tags in GHCR
+crane ls ghcr.io/arustydev/helm-charts/cloudflared
+
+# List GitHub releases
+gh release list --repo aRustyDev/helm-charts
+```
+
+## Next Steps
+
+- [Lineage Tracing](./lineage.md) - Trace complete provenance chain
+- [Limitations](./limitations.md) - Understand what attestations don't prove


### PR DESCRIPTION
## Summary

Promote attestation documentation from integration to main.

This PR adds comprehensive attestation and provenance documentation.

## Documentation Added

### `docs/src/attestation/`

| File | Purpose |
|------|---------|
| `index.md` | Overview of attestations, pipeline flow, security model |
| `verification.md` | Verification commands for GHCR, GitHub Releases, Helm repo |
| `lineage.md` | Complete provenance chain tracing with scripts |
| `limitations.md` | What attestations don't prove, trust boundaries |

## E2E Tests Added (in test plan)

- E2E-5 through E2E-10 covering attestation failure scenarios

## Source

Cherry-picked from integration PR #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)