### PR TITLE
docs: add GitHub App token pattern with 1Password integration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,6 +15,52 @@ Charts requiring external services are excluded from install tests but still lin
 - `ct-install.yaml` - install config (excludes charts needing external services)
 - See [ADR-007](../docs/src/adr/007-separate-ct-configs.md) for details
 
+### Workflow Authentication: GitHub App Token Pattern
+When a workflow needs elevated permissions (bypass branch protection, trigger other workflows, push to protected branches), **use a GitHub App token instead of `GITHUB_TOKEN`**.
+
+**Pattern (with 1Password - Preferred):**
+```yaml
+jobs:
+  generate-token:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Load secrets from 1Password
+        id: op-secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
+          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
+
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
+
+  my-job:
+    needs: [generate-token]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ needs.generate-token.outputs.token }}
+```
+
+**When to use:**
+- Pushing to protected branches
+- Bypassing ruleset rules
+- Creating PRs/commits that should trigger other workflows
+- Any operation where `GITHUB_TOKEN` is insufficient
+
+**Do NOT use `GITHUB_TOKEN` for:** force pushes, ruleset bypass, triggering workflows
+
+- See [GitHub App Authentication Guide](../docs/src/ci/github-app-auth.md) for full details
+- See [ADR-012](../docs/src/adr/012-github-app-token-pattern.md) for decision rationale
+
 ## CI Configuration Quick Reference
 
 | Setting | Value | Reason |
@@ -33,3 +79,6 @@ Repository uses a structured labeling system for issues and PRs.
 Full ADRs are located in `docs/src/adr/`:
 - [ADR-006: Release-Please for Helm Chart Versioning](../docs/src/adr/006-release-please-versioning.md)
 - [ADR-007: Separate Chart-Testing Configs for Lint vs Install](../docs/src/adr/007-separate-ct-configs.md)
+- [ADR-010: Linear History and Rebase Workflow](../docs/src/adr/010-linear-history-rebase.md)
+- [ADR-011: Full Atomization Model](../docs/src/adr/011-full-atomization-model.md)
+- [ADR-012: GitHub App Token Pattern for Workflows](../docs/src/adr/012-github-app-token-pattern.md)

--- a/.github/workflows/atomize-integration-pr.yaml
+++ b/.github/workflows/atomize-integration-pr.yaml
@@ -12,6 +12,9 @@
 #
 # Failure handling: If any step fails, cleanup pushed branches and
 # do NOT reset integration.
+#
+# Authentication: Uses GitHub App token for elevated permissions
+# Required secrets: OP_SERVICE_ACCOUNT_TOKEN (1Password)
 
 name: Atomize Integration PR
 
@@ -31,6 +34,29 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  generate-token:
+    name: Generate App Token
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Load secrets from 1Password
+        id: op-secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
+          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
+
   should-run:
     name: Check Trigger
     runs-on: ubuntu-latest
@@ -50,7 +76,7 @@ jobs:
 
   analyze:
     name: Analyze Merged PR
-    needs: should-run
+    needs: [generate-token, should-run]
     if: needs.should-run.outputs.run == 'true'
     runs-on: ubuntu-latest
     outputs:
@@ -64,6 +90,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: integration
+          token: ${{ needs.generate-token.outputs.token }}
 
       - name: Install dependencies
         run: |
@@ -73,7 +100,7 @@ jobs:
       - name: Get changed files from merged PR
         id: changed
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
         run: |
           # Get files that were in the merged PR
           FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
@@ -113,7 +140,7 @@ jobs:
 
   extract:
     name: Extract to Atomic Branches
-    needs: analyze
+    needs: [generate-token, analyze]
     if: needs.analyze.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     outputs:
@@ -124,7 +151,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.generate-token.outputs.token }}
 
       - name: Configure git
         run: |
@@ -195,7 +222,7 @@ jobs:
       - name: Create PRs (Pass 1)
         id: create-prs
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
           BRANCHES: ${{ steps.extract.outputs.branches }}
           SOURCE_PR: ${{ needs.analyze.outputs.source_pr }}
         run: |
@@ -232,7 +259,7 @@ jobs:
 
       - name: Update PRs with related links (Pass 2)
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
           PR_MAP: ${{ steps.create-prs.outputs.prs }}
           SOURCE_PR: ${{ needs.analyze.outputs.source_pr }}
         shell: bash
@@ -264,7 +291,7 @@ jobs:
 
   handle-dlq:
     name: Handle DLQ Files
-    needs: analyze
+    needs: [generate-token, analyze]
     if: needs.analyze.outputs.dlq_files != '[]' && needs.analyze.outputs.dlq_files != ''
     runs-on: ubuntu-latest
     steps:
@@ -272,7 +299,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.generate-token.outputs.token }}
 
       - name: Configure git
         run: |
@@ -308,7 +335,7 @@ jobs:
 
       - name: Create DLQ issue
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
           DLQ_FILES: ${{ needs.analyze.outputs.dlq_files }}
           SOURCE_PR: ${{ needs.analyze.outputs.source_pr }}
         shell: bash
@@ -341,7 +368,7 @@ jobs:
 
   reset-integration:
     name: Reset Integration
-    needs: [analyze, extract]
+    needs: [generate-token, analyze, extract]
     if: always() && needs.analyze.outputs.has_changes == 'true' && needs.extract.result == 'success'
     runs-on: ubuntu-latest
     steps:
@@ -349,7 +376,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.generate-token.outputs.token }}
 
       - name: Configure git
         run: |
@@ -357,7 +384,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Reset integration to main
+        env:
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
         run: |
+          # Use the app token for authenticated push
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git fetch origin main integration
           git checkout integration
           git reset --hard origin/main
           git push origin integration --force-with-lease
@@ -365,13 +397,13 @@ jobs:
 
   cleanup-on-failure:
     name: Cleanup on Failure
-    needs: [analyze, extract]
+    needs: [generate-token, analyze, extract]
     if: failure() && needs.extract.result == 'failure'
     runs-on: ubuntu-latest
     steps:
       - name: Delete created branches
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
           BRANCHES: ${{ needs.extract.outputs.created_branches }}
         run: |
           if [[ -z "$BRANCHES" ]] || [[ "$BRANCHES" == "[]" ]]; then
@@ -388,7 +420,7 @@ jobs:
 
       - name: Create failure issue
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
           SOURCE_PR: ${{ needs.analyze.outputs.source_pr }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         shell: bash
@@ -418,7 +450,7 @@ jobs:
 
   summary:
     name: Summary
-    needs: [analyze, extract, handle-dlq, reset-integration]
+    needs: [generate-token, analyze, extract, handle-dlq, reset-integration]
     if: always() && needs.analyze.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,7 @@
 # CI/CD
 
 - [Workflow Overview](./ci/index.md)
+  - [GitHub App Authentication](./ci/github-app-auth.md)
   - [Lint and Test](./ci/lint-test.md)
   - [Release Please](./ci/release-please.md)
   - [Release Charts](./ci/release.md)
@@ -34,6 +35,9 @@
   - [ADR-005: CI/CD Workflow Architecture](./adr/005-ci-workflows.md)
   - [ADR-006: Release-Please for Helm Chart Versioning](./adr/006-release-please-versioning.md)
   - [ADR-007: Separate Chart-Testing Configs](./adr/007-separate-ct-configs.md)
+  - [ADR-010: Linear History and Rebase Workflow](./adr/010-linear-history-rebase.md)
+  - [ADR-011: Full Atomization Model](./adr/011-full-atomization-model.md)
+  - [ADR-012: GitHub App Token Pattern](./adr/012-github-app-token-pattern.md)
 
 # Security
 
@@ -42,6 +46,11 @@
   - [Verification Methods](./attestation/verification.md)
   - [Lineage Tracing](./attestation/lineage.md)
   - [Limitations](./attestation/limitations.md)
+
+# Troubleshooting
+
+- [Commitlint Conflicts](./troubleshooting/commitlint-conflicts.md)
+- [CI Known Issues](./troubleshooting/ci-known-issues.md)
 
 # Contributing
 

--- a/docs/src/adr/012-github-app-token-pattern.md
+++ b/docs/src/adr/012-github-app-token-pattern.md
@@ -1,0 +1,212 @@
+# ADR-012: GitHub App Token Pattern for Workflows
+
+## Status
+
+Accepted
+
+## Context
+
+GitHub Actions workflows authenticate using `GITHUB_TOKEN` (also `github.token` or `secrets.GITHUB_TOKEN`) by default. This token has several limitations that impact CI/CD automation:
+
+### Limitations of GITHUB_TOKEN
+
+| Limitation | Impact |
+|------------|--------|
+| Cannot trigger workflows | PRs/pushes made with `GITHUB_TOKEN` won't trigger `on: push` or `on: pull_request` workflows |
+| Cannot bypass branch protection | Even with admin bypass configured on rulesets, `GITHUB_TOKEN` cannot utilize bypass privileges |
+| Repository-scoped only | Cannot perform cross-repository operations |
+| Single identity | All actions appear from `github-actions[bot]`, reducing traceability |
+
+### Specific Problem: W2 Atomization
+
+The W2 atomization workflow (`atomize-integration-pr.yaml`) needs to:
+1. Push to atomic branches (`charts/*`, `ci/*`, etc.)
+2. Create PRs to main
+3. Force-push to reset the integration branch
+
+The integration branch is protected by rulesets that block force pushes. While admin bypass is configured, `GITHUB_TOKEN` cannot utilize this bypass, causing the workflow to fail.
+
+### Available Solutions
+
+1. **Personal Access Token (PAT)**: Works but tied to individual user, security concerns
+2. **Deploy Key**: SSH-based, limited to repository access
+3. **GitHub App Token**: First-class app identity, configurable permissions, auditable
+
+## Decision
+
+Adopt the **GitHub App Token Pattern** as the standard for workflows requiring elevated permissions.
+
+### Pattern Structure (with 1Password - Preferred)
+
+```yaml
+jobs:
+  generate-token:
+    name: Generate App Token
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Load secrets from 1Password
+        id: op-secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
+          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
+
+  my-job:
+    needs: [generate-token]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ needs.generate-token.outputs.token }}
+```
+
+### Required Secrets
+
+**With 1Password (Preferred):**
+
+| Secret | Description |
+|--------|-------------|
+| `OP_SERVICE_ACCOUNT_TOKEN` | 1Password Service Account token |
+
+App credentials stored in 1Password vault at `op://gh-shared/xauth/app/`.
+
+**With GitHub Secrets (Alternative):**
+
+| Secret | Description |
+|--------|-------------|
+| `APP_ID` | GitHub App ID |
+| `APP_PRIVATE_KEY` | GitHub App private key (PEM format) |
+
+### GitHub App: github-app-x-auth
+
+Use the existing [github-app-x-auth](https://github.com/aRustyDev/github-app-x-auth) app for authentication. This app:
+- Is installed globally across repositories
+- Provides traceability for automated actions
+- Has configurable permissions per installation
+
+### Token Scoping
+
+By default, tokens are scoped to the **current repository only**:
+
+```yaml
+# Default: single-repo scope (PREFERRED)
+- uses: actions/create-github-app-token@v1
+  with:
+    app-id: ${{ secrets.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+For cross-repository operations (use sparingly):
+
+```yaml
+# Explicit multi-repo scope
+- uses: actions/create-github-app-token@v1
+  with:
+    app-id: ${{ secrets.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+    repositories: "repo1,repo2"
+```
+
+### When to Use This Pattern
+
+Use GitHub App tokens when a workflow needs to:
+
+| Operation | GITHUB_TOKEN | App Token |
+|-----------|--------------|-----------|
+| Push to protected branches | No | Yes |
+| Bypass ruleset rules | No | Yes (if added as bypass actor) |
+| Trigger other workflows | No | Yes |
+| Custom commit author | No | Yes |
+| Cross-repo operations | No | Yes |
+
+### Ruleset Configuration
+
+For the app to bypass branch protection, add it as a bypass actor:
+
+1. Settings > Rules > Rulesets > [Ruleset Name]
+2. Bypass list > Add bypass
+3. Select the GitHub App
+4. Set bypass mode to "Always"
+
+## Consequences
+
+### Positive
+
+- **Bypasses limitations**: App tokens can bypass rulesets, trigger workflows, etc.
+- **Traceability**: Actions attributed to specific app, not generic bot
+- **Security**: Tokens are short-lived, scoped, and auditable
+- **Reusability**: Same app works across all repositories
+- **No PAT management**: Eliminates individual PAT security concerns
+
+### Negative
+
+- **Setup complexity**: Requires GitHub App creation and secret management
+- **Additional job**: Token generation adds workflow execution time (~5s)
+- **Secret management**: Must securely store `APP_PRIVATE_KEY`
+
+### Neutral
+
+- Workflows become slightly more verbose with the generate-token job
+- Debugging may require understanding app token vs GITHUB_TOKEN behavior
+
+## Implementation
+
+### Completed
+
+1. **W2 Atomization Workflow**: Updated `atomize-integration-pr.yaml` to use app token pattern
+2. **Documentation**: Created `docs/src/ci/github-app-auth.md`
+3. **Ruleset Split**: Created `integration-linear-history` without `non_fast_forward` rule
+
+### Required (Manual)
+
+1. Add `APP_ID` and `APP_PRIVATE_KEY` secrets to repository
+2. Add GitHub App as bypass actor on `integration-pr-required` ruleset
+
+### Future
+
+Apply this pattern to any new workflows requiring elevated permissions.
+
+## Alternatives Considered
+
+### Personal Access Token (PAT)
+
+```yaml
+token: ${{ secrets.PAT }}
+```
+
+**Rejected**: Tied to individual user account, security risk if compromised, no fine-grained permissions.
+
+### Deploy Key
+
+```yaml
+ssh-key: ${{ secrets.DEPLOY_KEY }}
+```
+
+**Rejected**: SSH-based (different auth mechanism), limited to read/write, no API access.
+
+### Fine-Grained PAT
+
+**Rejected**: Still tied to user account, expires, requires user management.
+
+### Keep Using GITHUB_TOKEN with Relaxed Rules
+
+**Rejected**: Would require removing important branch protections, reducing security.
+
+## Related
+
+- [GitHub App Authentication](../ci/github-app-auth.md) - Detailed usage guide
+- [ADR-010: Linear History and Rebase Workflow](010-linear-history-rebase.md) - Ruleset context
+- [ADR-011: Full Atomization Model](011-full-atomization-model.md) - W2 workflow context
+- [actions/create-github-app-token](https://github.com/actions/create-github-app-token) - Official action
+- [github-app-x-auth](https://github.com/aRustyDev/github-app-x-auth) - The GitHub App used

--- a/docs/src/adr/index.md
+++ b/docs/src/adr/index.md
@@ -19,6 +19,9 @@ An Architecture Decision Record (ADR) captures an important architectural decisi
 | [ADR-007](./007-separate-ct-configs.md) | Separate Chart-Testing Configs | Accepted |
 | [ADR-008](./008-repository-dispatch-automation.md) | Repository Dispatch for Workflow Automation | Accepted |
 | [ADR-009](./009-integration-auto-merge.md) | Trust-Based Auto-Merge for Integration Branch | Accepted |
+| [ADR-010](./010-linear-history-rebase.md) | Linear History and Rebase Workflow | Accepted |
+| [ADR-011](./011-full-atomization-model.md) | Full Atomization Model | Accepted |
+| [ADR-012](./012-github-app-token-pattern.md) | GitHub App Token Pattern for Workflows | Accepted |
 
 ## ADR Template
 

--- a/docs/src/ci/github-app-auth.md
+++ b/docs/src/ci/github-app-auth.md
@@ -1,0 +1,308 @@
+# GitHub App Authentication in Workflows
+
+This document describes the standard pattern for authenticating GitHub Actions workflows using a GitHub App token instead of `GITHUB_TOKEN`.
+
+## Why Use a GitHub App Token?
+
+The default `GITHUB_TOKEN` (also `github.token` or `secrets.GITHUB_TOKEN`) has limitations:
+
+| Limitation | Impact |
+|------------|--------|
+| Cannot trigger other workflows | PRs/pushes made with `GITHUB_TOKEN` won't trigger `on: push` or `on: pull_request` workflows |
+| Cannot bypass branch protection | Even with admin bypass configured on rulesets, `GITHUB_TOKEN` cannot utilize it |
+| Limited to current repository | Cannot perform cross-repo operations |
+| Associated with `github-actions[bot]` | All actions appear from the same bot account |
+
+A GitHub App token solves these issues by acting as a first-class GitHub App with configurable permissions.
+
+## Standard Pattern
+
+There are two approaches to providing the GitHub App credentials:
+
+### Option A: 1Password Integration (Preferred)
+
+Use 1Password to securely store and retrieve the App credentials:
+
+```yaml
+jobs:
+  generate-token:
+    name: Generate App Token
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Load secrets from 1Password
+        id: op-secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
+          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
+```
+
+**Advantages of 1Password:**
+- Centralized secret management across repositories
+- Automatic secret rotation support
+- Audit trail for secret access
+- No need to duplicate secrets per repository
+
+### Option B: GitHub Secrets (Simple)
+
+Store credentials directly in GitHub repository secrets:
+
+```yaml
+jobs:
+  generate-token:
+    name: Generate App Token
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+### 2. Consume Token in Dependent Jobs
+
+Jobs that need elevated permissions should:
+1. Depend on `generate-token`
+2. Use the token from outputs
+
+```yaml
+  my-job:
+    needs: [generate-token]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ needs.generate-token.outputs.token }}
+
+      - name: Use gh CLI
+        env:
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
+        run: |
+          gh pr create --title "My PR" --body "Created with app token"
+```
+
+### 3. Authenticated Git Push
+
+For pushing to protected branches:
+
+```yaml
+      - name: Push with App Token
+        env:
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin my-branch --force-with-lease
+```
+
+## Required Secrets
+
+### With 1Password (Preferred)
+
+| Secret | Description |
+|--------|-------------|
+| `OP_SERVICE_ACCOUNT_TOKEN` | 1Password Service Account token |
+
+The App ID and private key are stored in 1Password at:
+- `op://gh-shared/xauth/app/id` - GitHub App ID
+- `op://gh-shared/xauth/app/private-key.pem` - Private key (PEM format)
+
+### With GitHub Secrets
+
+| Secret | Description | How to Obtain |
+|--------|-------------|---------------|
+| `APP_ID` | GitHub App ID | App settings page > App ID |
+| `APP_PRIVATE_KEY` | Private key in PEM format | App settings > Private keys > Generate |
+
+## Token Scoping
+
+By default, tokens are scoped to the **current repository only**, even if the app is installed globally.
+
+```yaml
+# Default: scoped to current repo
+- uses: actions/create-github-app-token@v1
+  with:
+    app-id: ${{ secrets.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+To access other repositories (use sparingly):
+
+```yaml
+# Explicit multi-repo scope
+- uses: actions/create-github-app-token@v1
+  with:
+    app-id: ${{ secrets.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+    repositories: "repo1,repo2"
+```
+
+## GitHub App Requirements
+
+### Minimum Permissions
+
+Configure these in your GitHub App settings:
+
+| Permission | Access | Common Use Cases |
+|------------|--------|------------------|
+| Contents | Read & Write | Push commits, create branches |
+| Pull requests | Read & Write | Create/update PRs |
+| Issues | Read & Write | Create issues |
+| Metadata | Read | Required for all apps |
+
+### Ruleset Bypass
+
+If the workflow needs to bypass branch protection rules:
+
+1. Go to: **Settings > Rules > Rulesets > [Your Ruleset]**
+2. Scroll to **Bypass list**
+3. Click **Add bypass**
+4. Select your GitHub App
+5. Set bypass mode to **Always**
+
+## Complete Example
+
+### With 1Password (Preferred)
+
+```yaml
+name: Example Workflow with App Token (1Password)
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read  # Minimal permissions for GITHUB_TOKEN
+
+jobs:
+  generate-token:
+    name: Generate App Token
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Load secrets from 1Password
+        id: op-secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
+          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
+
+  create-pr:
+    name: Create PR
+    needs: [generate-token]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ needs.generate-token.outputs.token }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Make changes and create PR
+        env:
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
+        run: |
+          git checkout -b automated-changes
+          echo "change" >> file.txt
+          git add .
+          git commit -m "chore: automated change"
+          git push origin automated-changes
+          gh pr create --title "Automated PR" --body "Created by workflow"
+```
+
+### With GitHub Secrets
+
+```yaml
+name: Example Workflow with App Token (GitHub Secrets)
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  generate-token:
+    name: Generate App Token
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+  create-pr:
+    name: Create PR
+    needs: [generate-token]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ needs.generate-token.outputs.token }}
+
+      - name: Make changes and create PR
+        env:
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
+        run: |
+          gh pr create --title "Automated PR" --body "Created by workflow"
+```
+
+## When to Use This Pattern
+
+Use GitHub App tokens when your workflow needs to:
+
+- Push to protected branches
+- Bypass branch protection rules
+- Create PRs that should trigger other workflows
+- Create commits with a custom author (not `github-actions[bot]`)
+- Perform operations that `GITHUB_TOKEN` cannot
+
+## Security Considerations
+
+1. **Principle of least privilege**: Only request permissions the app actually needs
+2. **Repository scoping**: Keep default single-repo scope unless cross-repo access is required
+3. **Secret management**: Store `APP_PRIVATE_KEY` securely (1Password, etc.)
+4. **Audit trail**: Actions taken with the app token are attributed to the app, providing traceability
+
+## Related
+
+- [ADR-012: GitHub App Token Pattern](../adr/012-github-app-token-pattern.md)
+- [actions/create-github-app-token](https://github.com/actions/create-github-app-token)
+- [GitHub Apps documentation](https://docs.github.com/en/apps)

--- a/docs/src/troubleshooting/ci-known-issues.md
+++ b/docs/src/troubleshooting/ci-known-issues.md
@@ -1,0 +1,54 @@
+# CI Known Issues
+
+This document tracks known issues and gaps in the CI/CD workflows.
+
+## W2 Atomization Workflow - GitHub App Token Required
+
+**Status**: Resolved (requires secrets configuration)
+**Severity**: Medium
+**Affected Workflow**: `atomize-integration-pr.yaml`
+
+### Description
+
+The W2 atomization workflow requires a GitHub App token with elevated permissions to reset the integration branch after atomization completes.
+
+### Resolution Applied
+
+1. **Ruleset reconfiguration**: Split `protected-branches-linear` ruleset:
+   - `protected-branches-linear`: Covers main/release with `non_fast_forward` rule
+   - `integration-linear-history` (NEW): Covers integration without `non_fast_forward` rule
+
+2. **Workflow updated**: Now uses GitHub App token via `actions/create-github-app-token@v1`
+
+### Required Secrets
+
+The workflow uses 1Password for secret management:
+
+| Secret | Description |
+|--------|-------------|
+| `OP_SERVICE_ACCOUNT_TOKEN` | 1Password Service Account token |
+
+App credentials are stored in 1Password at `op://gh-shared/xauth/app/`.
+
+### GitHub App Permissions
+
+The GitHub App must have:
+- **Repository permissions**:
+  - Contents: Read and write
+  - Pull requests: Read and write
+  - Issues: Read and write
+- **Bypass actor**: Added to `integration-pr-required` ruleset via GitHub UI
+
+### Setup Steps
+
+1. Ensure `github-app-x-auth` is installed on the repository
+2. Ensure `OP_SERVICE_ACCOUNT_TOKEN` secret is configured
+3. Add the GitHub App as bypass actor on `integration-pr-required` ruleset via UI:
+   - Go to: Settings > Rules > Rulesets > `integration-pr-required`
+   - Bypass list > Add bypass > Select `github-app-x-auth`
+
+### Related
+
+- Rulesets: `protected-branches-linear`, `integration-linear-history`, `integration-pr-required`
+- Workflow: `.github/workflows/atomize-integration-pr.yaml`
+- ADR: [ADR-011: Full Atomization Model](../adr/011-full-atomization-model.md)


### PR DESCRIPTION
## Summary

Add comprehensive documentation for the GitHub App token authentication pattern used in workflows requiring elevated permissions.

- Add ADR-012: GitHub App Token Pattern for Workflows
- Add `docs/src/ci/github-app-auth.md` with full usage guide
- Add `docs/src/troubleshooting/ci-known-issues.md`
- Update `.claude/CLAUDE.md` with pattern as key decision
- Update `atomize-integration-pr.yaml` to use 1Password pattern
- Update `docs/src/SUMMARY.md` and ADR index

## Pattern Overview

The pattern uses 1Password (preferred) for centralized secret management:

```yaml
- name: Load secrets from 1Password
  uses: 1password/load-secrets-action@v2
  with:
    export-env: false
  env:
    OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
    X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
    X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem

- name: Generate GitHub App Token
  uses: actions/create-github-app-token@v1
  with:
    app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
    private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
```

## Test plan

- [x] YAML syntax validation passes
- [ ] Documentation renders correctly in mdbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ATTESTATION_MAP
{"commit-validation":"17025546"}
-->