### PR TITLE
fix(ci): correct client_payload format in W2 dispatch

### DIFF
--- a/.github/workflows/create-atomic-chart-pr.yaml
+++ b/.github/workflows/create-atomic-chart-pr.yaml
@@ -345,10 +345,12 @@ jobs:
           echo "::notice::Triggering W5 validation for PR #$PR_NUMBER (chart: $CHART)"
 
           # Dispatch repository event to trigger W5
+          # Note: client_payload must be a JSON object, not a string
+          jq -n --argjson pr "$PR_NUMBER" --arg chart "$CHART" \
+            '{event_type: "chart-pr-created", client_payload: {pr: $pr, chart: $chart}}' | \
           gh api "repos/${{ github.repository }}/dispatches" \
             --method POST \
-            -f event_type=chart-pr-created \
-            -f client_payload="{\"pr\": $PR_NUMBER, \"chart\": \"$CHART\"}"
+            --input -
 
           echo "::notice::W5 validation triggered successfully"
 


### PR DESCRIPTION
## Summary

- Fixed `client_payload` format in W2 workflow's repository dispatch call
- Changed from `-f` flag (string) to piping JSON via `--input -` (object)

## Problem

The W2 workflow (`create-atomic-chart-pr.yaml`) was failing with:
```
Invalid request.
For 'properties/client_payload', "{\"pr\": 118, \"chart\": \"test-workflow\"}" is not an object.
```

## Solution

The `client_payload` parameter in GitHub's repository dispatch API must be a JSON object, not a string. The `-f` flag in `gh api` sends form data as strings.

Changed from:
```bash
gh api "repos/.../dispatches" \
  -f event_type=chart-pr-created \
  -f client_payload="{\"pr\": $PR_NUMBER, \"chart\": \"$CHART\"}"
```

To:
```bash
jq -n --argjson pr "$PR_NUMBER" --arg chart "$CHART" \
  '{event_type: "chart-pr-created", client_payload: {pr: $pr, chart: $chart}}' | \
gh api "repos/.../dispatches" --input -
```

## Test plan

- [ ] W1 validation passes
- [ ] PR merges to integration
- [ ] W2 dispatch call succeeds
- [ ] W5 workflow triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ATTESTATION_MAP
{"commit-validation":"17031083"}
-->