### PR TITLE
fix(ci): add always() to W5 lint/test job conditions

### DIFF
--- a/.github/workflows/validate-atomic-chart-pr.yaml
+++ b/.github/workflows/validate-atomic-chart-pr.yaml
@@ -231,7 +231,10 @@ jobs:
   # Phase 5.2: ArtifactHub metadata linting
   artifacthub-lint:
     needs: validate-and-detect
-    if: needs.validate-and-detect.outputs.has_charts == 'true'
+    if: |
+      always() &&
+      needs.validate-and-detect.result == 'success' &&
+      needs.validate-and-detect.outputs.has_charts == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -262,7 +265,10 @@ jobs:
   # Phase 5.3: Helm chart linting
   helm-lint:
     needs: validate-and-detect
-    if: needs.validate-and-detect.outputs.has_charts == 'true'
+    if: |
+      always() &&
+      needs.validate-and-detect.result == 'success' &&
+      needs.validate-and-detect.outputs.has_charts == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -294,7 +300,11 @@ jobs:
   k8s-matrix-test:
     name: k8s-test (${{ matrix.k8s_version }})
     needs: [validate-and-detect, helm-lint]
-    if: needs.validate-and-detect.outputs.has_charts == 'true'
+    if: |
+      always() &&
+      needs.validate-and-detect.result == 'success' &&
+      needs.helm-lint.result == 'success' &&
+      needs.validate-and-detect.outputs.has_charts == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

- Added `always()` to W5 lint/test job conditions to fix job skipping issue
- Updated `artifacthub-lint`, `helm-lint`, and `k8s-matrix-test` jobs

## Problem

When `validate-and-detect` job uses `always()` with a skipped upstream job (`validate-dispatch`), downstream jobs that depend on its outputs were incorrectly skipping even when charts were detected.

**Root cause**: GitHub Actions job condition evaluation behaves differently when there are skipped jobs in the dependency chain. Without `always()`, the condition may not be evaluated at all.

## Solution

Changed job conditions from:
```yaml
if: needs.validate-and-detect.outputs.has_charts == 'true'
```

To:
```yaml
if: |
  always() &&
  needs.validate-and-detect.result == 'success' &&
  needs.validate-and-detect.outputs.has_charts == 'true'
```

This ensures:
1. The condition is always evaluated (`always()`)
2. Only runs if `validate-and-detect` succeeded
3. Only runs if charts were detected

## Test plan

- [x] Verified fix works on PR #118 (E2E-1 test)
- [ ] W1 validation passes on this PR
- [ ] Auto-merge to integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ATTESTATION_MAP
{"commit-validation":"17034272"}
-->