### PR TITLE
feat(ci): split W6 into tag creation and release workflows

### DIFF
--- a/.github/workflows/release-atomic-chart.yaml
+++ b/.github/workflows/release-atomic-chart.yaml
@@ -1,26 +1,28 @@
-# Release Atomic Chart
+# Release Atomic Chart (W6)
 #
-# Combined workflow for tagging, packaging, and publishing Helm charts.
-# Triggered when chart changes are merged to main.
+# Tag-based workflow for packaging and publishing Helm charts.
+# Triggered when chart tags are pushed (<chart>-v<version>).
 #
 # This workflow:
-#   1. Detects which charts changed in the merge
-#   2. Creates git tags for each chart (<chart>-v<version>)
-#   3. Packages charts and generates build attestations
-#   4. Publishes to GHCR with Cosign signing
-#   5. Creates GitHub Releases with signatures
-#   6. Updates release branch with packages and index.yaml
+#   1. Validates tag format matches <chart>-v<version> pattern
+#   2. Validates chart directory exists in charts/<chart>
+#   3. Validates Chart.yaml version matches tag version
+#   4. Packages charts and generates build attestations
+#   5. Publishes to GHCR with Cosign signing
+#   6. Creates GitHub Releases with signatures
+#   7. Updates release branch with packages and index.yaml
 #
-# Note: Source branch cleanup is handled by validate-atomic-chart-pr.yaml on merge
+# Tags are created by:
+#   - Release-please (automated version bumps)
+#   - Manual tagging for hotfixes
+#   - W6-tag workflow (future)
 
 name: Release Atomic Chart
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'charts/**'
+    tags:
+      - '*-v*'  # Matches: cloudflared-v0.1.0, test-workflow-v1.2.3, etc.
 
 permissions:
   contents: write
@@ -30,255 +32,115 @@ permissions:
   attestations: write
 
 concurrency:
-  group: chart-release-${{ github.sha }}
+  group: chart-release-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   # ==========================================================================
-  # Phase 1: Detect changed charts and create tags
+  # Phase 1: Validate tag and extract chart info
   # ==========================================================================
-  detect-and-tag:
+  validate-tag:
     runs-on: ubuntu-latest
     outputs:
-      charts: ${{ steps.detect.outputs.charts }}
-      has_charts: ${{ steps.detect.outputs.has_charts }}
-      tags_created: ${{ steps.create-tags.outputs.tags_created }}
-      tag_list: ${{ steps.create-tags.outputs.tag_list }}
-      tag_list_json: ${{ steps.create-tags.outputs.tag_list_json }}
-      attestation_map: ${{ steps.source-pr.outputs.attestation_map }}
+      chart: ${{ steps.parse.outputs.chart }}
+      version: ${{ steps.parse.outputs.version }}
+      tag: ${{ steps.parse.outputs.tag }}
+      valid: ${{ steps.validate.outputs.valid }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Load secrets from 1Password
-        id: op-secrets
-        uses: 1password/load-secrets-action@v2
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
-          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
-
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
-          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
-
-      - name: Configure Git
+      - name: Parse Tag
+        id: parse
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          TAG="${GITHUB_REF_NAME}"
 
-      - name: Detect Changed Charts
-        id: detect
-        run: |
-          source .github/scripts/attestation-lib.sh
+          echo "::notice::Processing tag: $TAG"
 
-          CHARTS=$(detect_changed_charts "HEAD~1..HEAD")
-
-          if [[ -z "$CHARTS" ]]; then
-            echo "::notice::No chart changes detected, skipping release"
-            echo "charts=" >> "$GITHUB_OUTPUT"
-            echo "has_charts=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "charts=$CHARTS" >> "$GITHUB_OUTPUT"
-          echo "has_charts=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::Charts to release: $CHARTS"
-
-      - name: Find Source PR
-        id: source-pr
-        if: steps.detect.outputs.has_charts == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          source .github/scripts/attestation-lib.sh
-
-          PR_NUMBER=$(get_source_pr "${{ github.sha }}")
-
-          if [[ -z "$PR_NUMBER" ]]; then
-            echo "::warning::Could not find source PR for commit ${{ github.sha }}"
-            echo "pr_number=" >> "$GITHUB_OUTPUT"
-            echo "attestation_map={}" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Source PR: #$PR_NUMBER"
-            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-
-            ATTESTATION_MAP=$(extract_attestation_map "$PR_NUMBER")
-            echo "attestation_map=$ATTESTATION_MAP" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create Tags
-        id: create-tags
-        if: steps.detect.outputs.has_charts == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          source .github/scripts/attestation-lib.sh
-
-          CHARTS="${{ steps.detect.outputs.charts }}"
-          PR_NUMBER="${{ steps.source-pr.outputs.pr_number }}"
-          ATTESTATION_MAP='${{ steps.source-pr.outputs.attestation_map }}'
-          COMMIT_SHA="${{ github.sha }}"
-
-          CREATED_TAGS=""
-          TAG_LIST=""
-          SKIPPED=""
-          FAILED=false
-
-          for chart in $CHARTS; do
-            echo "::group::Processing $chart"
-
-            CHART_YAML="charts/$chart/Chart.yaml"
-            if [[ ! -f "$CHART_YAML" ]]; then
-              echo "::warning::Chart.yaml not found for $chart, skipping"
-              echo "::endgroup::"
-              continue
-            fi
-
-            VERSION=$(grep '^version:' "$CHART_YAML" | awk '{print $2}' | tr -d '"' | tr -d "'")
-            if [[ -z "$VERSION" ]]; then
-              echo "::error::Could not extract version from $CHART_YAML"
-              FAILED=true
-              echo "::endgroup::"
-              continue
-            fi
-
-            TAG_NAME="${chart}-v${VERSION}"
-            echo "Tag: $TAG_NAME, Version: $VERSION"
-
-            # Check if tag already exists
-            if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-              EXISTING_COMMIT=$(git rev-list -n 1 "$TAG_NAME")
-              if [[ "$EXISTING_COMMIT" == "$COMMIT_SHA" ]]; then
-                echo "::notice::Tag $TAG_NAME already exists at this commit, skipping"
-                SKIPPED="${SKIPPED} ${TAG_NAME}"
-                echo "::endgroup::"
-                continue
-              else
-                echo "::error::Tag $TAG_NAME exists but points to different commit!"
-                echo "::error::This indicates version was not bumped properly."
-                FAILED=true
-                echo "::endgroup::"
-                continue
-              fi
-            fi
-
-            # Extract changelog
-            CHANGELOG=$(extract_changelog_for_version "$chart" "$VERSION")
-
-            # Format attestation lineage
-            if [[ -n "$ATTESTATION_MAP" && "$ATTESTATION_MAP" != "{}" ]]; then
-              ATTESTATION_LINEAGE=$(echo "$ATTESTATION_MAP" | jq -r 'to_entries | .[] | "- \(.key): \(.value)"' 2>/dev/null || echo "- Parse error")
-            else
-              ATTESTATION_LINEAGE="- No attestation data available"
-            fi
-
-            # Create annotated tag
-            git tag -a "$TAG_NAME" -m "$(cat <<EOF
-          Release: $chart v$VERSION
-
-          Attestation Lineage:
-          $ATTESTATION_LINEAGE
-
-          Changelog:
-          $CHANGELOG
-
-          Source PR: #${PR_NUMBER:-unknown}
-          Commit: $COMMIT_SHA
-          EOF
-          )"
-
-            git push origin "$TAG_NAME"
-            echo "::notice::Created and pushed tag: $TAG_NAME"
-
-            # Track for downstream jobs
-            if [[ -z "$CREATED_TAGS" ]]; then
-              CREATED_TAGS="$TAG_NAME"
-              TAG_LIST="$chart:$VERSION"
-            else
-              CREATED_TAGS="${CREATED_TAGS},${TAG_NAME}"
-              TAG_LIST="${TAG_LIST} ${chart}:${VERSION}"
-            fi
-
-            echo "::endgroup::"
-          done
-
-          echo "tags_created=$CREATED_TAGS" >> "$GITHUB_OUTPUT"
-          echo "tag_list=$TAG_LIST" >> "$GITHUB_OUTPUT"
-          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
-
-          # Create JSON array for matrix
-          if [[ -n "$TAG_LIST" ]]; then
-            TAG_LIST_JSON=$(echo "$TAG_LIST" | tr ' ' '\n' | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          else
-            TAG_LIST_JSON="[]"
-          fi
-          echo "tag_list_json=$TAG_LIST_JSON" >> "$GITHUB_OUTPUT"
-
-          if [[ "$FAILED" == "true" ]]; then
-            echo "::error::One or more tags failed to create"
+          # Validate tag format: <chart>-v<version>
+          # Chart names can contain hyphens, so we match from the right
+          # Pattern: everything before last "-v" is chart name, after is version
+          if [[ ! "$TAG" =~ ^(.+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
+            echo "::error::Invalid tag format: $TAG"
+            echo "::error::Expected format: <chart>-v<version> (e.g., cloudflared-v0.1.0)"
             exit 1
           fi
 
-  # ==========================================================================
-  # Phase 2: Package charts and generate attestations
-  # ==========================================================================
-  package-charts:
-    needs: detect-and-tag
-    if: needs.detect-and-tag.outputs.has_charts == 'true' && needs.detect-and-tag.outputs.tags_created != ''
-    runs-on: ubuntu-latest
-    outputs:
-      packages: ${{ steps.package.outputs.packages }}
-    strategy:
-      matrix:
-        chart_version: ${{ fromJson(needs.detect-and-tag.outputs.tag_list_json) }}
-      fail-fast: false
-    steps:
-      - name: Parse Chart Info
-        id: parse
-        run: |
-          CHART_VERSION="${{ matrix.chart_version }}"
-          CHART="${CHART_VERSION%%:*}"
-          VERSION="${CHART_VERSION##*:}"
-          TAG="${CHART}-v${VERSION}"
+          CHART="${BASH_REMATCH[1]}"
+          VERSION="${BASH_REMATCH[2]}"
 
           echo "chart=$CHART" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-          echo "::notice::Processing $CHART v$VERSION"
+          echo "::notice::Chart: $CHART"
+          echo "::notice::Version: $VERSION"
 
-      - name: Checkout Tag
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.parse.outputs.tag }}
-          fetch-depth: 0
 
-      - name: Validate Chart
+      - name: Validate Chart Exists
+        id: validate
         run: |
           CHART="${{ steps.parse.outputs.chart }}"
           VERSION="${{ steps.parse.outputs.version }}"
-          CHART_YAML="charts/$CHART/Chart.yaml"
+          CHART_DIR="charts/$CHART"
+          CHART_YAML="$CHART_DIR/Chart.yaml"
 
+          echo "::group::Validating chart: $CHART"
+
+          # Check chart directory exists
+          if [[ ! -d "$CHART_DIR" ]]; then
+            echo "::error::Chart directory not found: $CHART_DIR"
+            echo "::error::Tag '${{ steps.parse.outputs.tag }}' does not match any chart in charts/"
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          # Check Chart.yaml exists
           if [[ ! -f "$CHART_YAML" ]]; then
             echo "::error::Chart.yaml not found: $CHART_YAML"
+            echo "valid=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
+          # Validate version matches
           CHART_VERSION=$(grep '^version:' "$CHART_YAML" | awk '{print $2}' | tr -d '"' | tr -d "'")
-          if [[ "$CHART_VERSION" != "$VERSION" ]]; then
-            echo "::error::Version mismatch! Tag: $VERSION, Chart.yaml: $CHART_VERSION"
+          if [[ -z "$CHART_VERSION" ]]; then
+            echo "::error::Could not extract version from $CHART_YAML"
+            echo "valid=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
-          echo "::notice::Validated Chart.yaml version matches tag"
+          if [[ "$CHART_VERSION" != "$VERSION" ]]; then
+            echo "::error::Version mismatch!"
+            echo "::error::Tag version: $VERSION"
+            echo "::error::Chart.yaml version: $CHART_VERSION"
+            echo "::error::Tag and Chart.yaml versions must match"
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          echo "::notice::Chart validated successfully"
+          echo "::notice::  Directory: $CHART_DIR"
+          echo "::notice::  Version: $VERSION"
+          echo "valid=true" >> "$GITHUB_OUTPUT"
+
+          echo "::endgroup::"
+
+  # ==========================================================================
+  # Phase 2: Package chart and generate attestations
+  # ==========================================================================
+  package-chart:
+    needs: validate-tag
+    if: needs.validate-tag.outputs.valid == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      package: ${{ steps.build.outputs.package }}
+      package_name: ${{ steps.build.outputs.package_name }}
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout Tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-tag.outputs.tag }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -288,8 +150,8 @@ jobs:
       - name: Build Package
         id: build
         run: |
-          CHART="${{ steps.parse.outputs.chart }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          CHART="${{ needs.validate-tag.outputs.chart }}"
+          VERSION="${{ needs.validate-tag.outputs.version }}"
 
           mkdir -p .cr-release-packages
 
@@ -322,45 +184,29 @@ jobs:
       - name: Upload Package Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: chart-package-${{ steps.parse.outputs.chart }}-${{ steps.parse.outputs.version }}
+          name: chart-package-${{ needs.validate-tag.outputs.chart }}-${{ needs.validate-tag.outputs.version }}
           path: ${{ steps.build.outputs.package }}
           retention-days: 7
 
   # ==========================================================================
   # Phase 3: Publish to all distribution channels
   # ==========================================================================
-  publish-releases:
-    needs: [detect-and-tag, package-charts]
-    if: needs.detect-and-tag.outputs.has_charts == 'true'
+  publish-release:
+    needs: [validate-tag, package-chart]
+    if: needs.validate-tag.outputs.valid == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        chart_version: ${{ fromJson(needs.detect-and-tag.outputs.tag_list_json) }}
-      fail-fast: false
     steps:
-      - name: Parse Chart Info
-        id: parse
-        run: |
-          CHART_VERSION="${{ matrix.chart_version }}"
-          CHART="${CHART_VERSION%%:*}"
-          VERSION="${CHART_VERSION##*:}"
-          TAG="${CHART}-v${VERSION}"
-
-          echo "chart=$CHART" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
       - name: Download Package
         uses: actions/download-artifact@v4
         with:
-          name: chart-package-${{ steps.parse.outputs.chart }}-${{ steps.parse.outputs.version }}
+          name: chart-package-${{ needs.validate-tag.outputs.chart }}-${{ needs.validate-tag.outputs.version }}
           path: .cr-release-packages/
 
       - name: Verify Package
         id: verify
         run: |
-          CHART="${{ steps.parse.outputs.chart }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          CHART="${{ needs.validate-tag.outputs.chart }}"
+          VERSION="${{ needs.validate-tag.outputs.version }}"
           PACKAGE_NAME="${CHART}-${VERSION}.tgz"
           PACKAGE_FILE=".cr-release-packages/$PACKAGE_NAME"
 
@@ -411,8 +257,8 @@ jobs:
       - name: Publish to GHCR
         id: publish-ghcr
         run: |
-          CHART="${{ steps.parse.outputs.chart }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          CHART="${{ needs.validate-tag.outputs.chart }}"
+          VERSION="${{ needs.validate-tag.outputs.version }}"
           PACKAGE="${{ steps.verify.outputs.package }}"
 
           REGISTRY="ghcr.io/${{ github.repository }}"
@@ -463,9 +309,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          CHART="${{ steps.parse.outputs.chart }}"
-          VERSION="${{ steps.parse.outputs.version }}"
-          TAG="${{ steps.parse.outputs.tag }}"
+          CHART="${{ needs.validate-tag.outputs.chart }}"
+          VERSION="${{ needs.validate-tag.outputs.version }}"
+          TAG="${{ needs.validate-tag.outputs.tag }}"
           PACKAGE="${{ steps.verify.outputs.package }}"
           DIGEST="${{ steps.verify.outputs.digest }}"
           OCI_DIGEST="${{ steps.publish-ghcr.outputs.oci_digest }}"
@@ -552,16 +398,32 @@ jobs:
   # Phase 4: Update release branch
   # ==========================================================================
   update-release-branch:
-    needs: [detect-and-tag, package-charts, publish-releases]
-    if: needs.detect-and-tag.outputs.has_charts == 'true'
+    needs: [validate-tag, package-chart, publish-release]
+    if: needs.validate-tag.outputs.valid == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Load secrets from 1Password
+        id: op-secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
+          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
+
       - name: Checkout Release Branch
         uses: actions/checkout@v4
         with:
           ref: release
-          # Use GITHUB_TOKEN which has admin bypass on release branch
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git
         run: |
@@ -573,45 +435,40 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Download All Packages
+      - name: Download Package
         uses: actions/download-artifact@v4
         with:
-          pattern: chart-package-*
+          name: chart-package-${{ needs.validate-tag.outputs.chart }}-${{ needs.validate-tag.outputs.version }}
           path: packages/
-          merge-multiple: true
 
       - name: Update Release Branch
         run: |
-          TAG_LIST="${{ needs.detect-and-tag.outputs.tag_list }}"
+          CHART="${{ needs.validate-tag.outputs.chart }}"
+          VERSION="${{ needs.validate-tag.outputs.version }}"
+          TAG="${{ needs.validate-tag.outputs.tag }}"
+          PACKAGE_NAME="${CHART}-${VERSION}.tgz"
 
-          echo "::group::Processing packages"
+          echo "::group::Processing package"
           ls -la packages/
           echo "::endgroup::"
 
-          # Copy packages and update index
-          for chart_version in $TAG_LIST; do
-            CHART="${chart_version%%:*}"
-            VERSION="${chart_version##*:}"
-            PACKAGE_NAME="${CHART}-${VERSION}.tgz"
-            TAG="${CHART}-v${VERSION}"
+          if [[ -f "packages/$PACKAGE_NAME" ]]; then
+            cp "packages/$PACKAGE_NAME" .
+            echo "::notice::Copied $PACKAGE_NAME"
 
-            if [[ -f "packages/$PACKAGE_NAME" ]]; then
-              cp "packages/$PACKAGE_NAME" .
-              echo "::notice::Copied $PACKAGE_NAME"
-
-              # Update index.yaml for this package
-              if [[ -f index.yaml ]]; then
-                helm repo index . \
-                  --url "https://github.com/${{ github.repository }}/releases/download/$TAG" \
-                  --merge index.yaml
-              else
-                helm repo index . \
-                  --url "https://github.com/${{ github.repository }}/releases/download/$TAG"
-              fi
+            # Update index.yaml for this package
+            if [[ -f index.yaml ]]; then
+              helm repo index . \
+                --url "https://github.com/${{ github.repository }}/releases/download/$TAG" \
+                --merge index.yaml
             else
-              echo "::warning::Package not found: $PACKAGE_NAME"
+              helm repo index . \
+                --url "https://github.com/${{ github.repository }}/releases/download/$TAG"
             fi
-          done
+          else
+            echo "::error::Package not found: packages/$PACKAGE_NAME"
+            exit 1
+          fi
 
           # Show changes
           echo "::group::Index changes"
@@ -620,21 +477,21 @@ jobs:
 
           # Commit and push
           git add index.yaml *.tgz
-          git commit -m "chore(release): publish charts
+          git commit -m "chore(release): publish $CHART v$VERSION
 
-          Charts: $TAG_LIST
+          Tag: $TAG
           Workflow: ${{ github.run_id }}
           Commit: ${{ github.sha }}" || echo "No changes to commit"
 
           git push origin release
 
-          echo "::notice::Updated release branch"
+          echo "::notice::Updated release branch with $CHART v$VERSION"
 
   # ==========================================================================
   # Summary
   # ==========================================================================
   summary:
-    needs: [detect-and-tag, package-charts, publish-releases, update-release-branch]
+    needs: [validate-tag, package-chart, publish-release, update-release-branch]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -643,26 +500,29 @@ jobs:
           {
             echo "## Release Atomic Chart - Summary"
             echo ""
+            echo "### Tag Information"
+            echo "- **Tag**: ${{ github.ref_name }}"
+            echo "- **Chart**: ${{ needs.validate-tag.outputs.chart }}"
+            echo "- **Version**: ${{ needs.validate-tag.outputs.version }}"
+            echo ""
             echo "### Results"
             echo "| Phase | Status |"
             echo "|-------|--------|"
-            echo "| Detect & Tag | ${{ needs.detect-and-tag.result == 'success' && ':white_check_mark:' || ':x:' }} |"
-            echo "| Package Charts | ${{ needs.package-charts.result == 'success' && ':white_check_mark:' || (needs.package-charts.result == 'skipped' && ':heavy_minus_sign:' || ':x:') }} |"
-            echo "| Publish Releases | ${{ needs.publish-releases.result == 'success' && ':white_check_mark:' || (needs.publish-releases.result == 'skipped' && ':heavy_minus_sign:' || ':x:') }} |"
+            echo "| Validate Tag | ${{ needs.validate-tag.result == 'success' && ':white_check_mark:' || ':x:' }} |"
+            echo "| Package Chart | ${{ needs.package-chart.result == 'success' && ':white_check_mark:' || (needs.package-chart.result == 'skipped' && ':heavy_minus_sign:' || ':x:') }} |"
+            echo "| Publish Release | ${{ needs.publish-release.result == 'success' && ':white_check_mark:' || (needs.publish-release.result == 'skipped' && ':heavy_minus_sign:' || ':x:') }} |"
             echo "| Update Release Branch | ${{ needs.update-release-branch.result == 'success' && ':white_check_mark:' || (needs.update-release-branch.result == 'skipped' && ':heavy_minus_sign:' || ':x:') }} |"
             echo ""
-            if [[ "${{ needs.detect-and-tag.outputs.has_charts }}" == "true" ]]; then
-              echo "### Charts Released"
-              echo "- Charts: ${{ needs.detect-and-tag.outputs.charts }}"
-              echo "- Tags: ${{ needs.detect-and-tag.outputs.tags_created }}"
-              echo ""
+            if [[ "${{ needs.validate-tag.outputs.valid }}" == "true" ]]; then
               echo "### Distribution"
               echo "| Channel | URL |"
               echo "|---------|-----|"
-              echo "| GHCR (OCI) | \`ghcr.io/${{ github.repository }}/<chart>:<version>\` |"
+              echo "| GHCR (OCI) | \`ghcr.io/${{ github.repository }}/${{ needs.validate-tag.outputs.chart }}:${{ needs.validate-tag.outputs.version }}\` |"
               echo "| Helm Repo | \`helm repo add arustydev https://charts.arusty.dev\` |"
-              echo "| GitHub Releases | [Releases](https://github.com/${{ github.repository }}/releases) |"
+              echo "| GitHub Release | [Release](https://github.com/${{ github.repository }}/releases/tag/${{ needs.validate-tag.outputs.tag }}) |"
             else
-              echo "No charts were released in this run."
+              echo "### Validation Failed"
+              echo "The tag did not pass validation. Check the logs for details."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+

--- a/.github/workflows/tag-atomic-chart.yaml
+++ b/.github/workflows/tag-atomic-chart.yaml
@@ -1,0 +1,245 @@
+# Tag Atomic Chart (W6-Tag)
+#
+# Creates release tags for charts when changes are merged to main.
+# This workflow triggers on push to main with chart changes, then creates
+# tags in the format <chart>-v<version> which trigger the release workflow.
+#
+# Flow:
+#   Push to main (charts/**) → W6-Tag creates tags → W6 releases each tagged chart
+
+name: Tag Atomic Chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: chart-tag-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  # ==========================================================================
+  # Detect changed charts and create tags
+  # ==========================================================================
+  create-tags:
+    runs-on: ubuntu-latest
+    outputs:
+      tags_created: ${{ steps.create-tags.outputs.tags_created }}
+      charts: ${{ steps.detect.outputs.charts }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Load secrets from 1Password
+        id: op-secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
+          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Detect Changed Charts
+        id: detect
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          CHARTS=$(detect_changed_charts "HEAD~1..HEAD")
+
+          if [[ -z "$CHARTS" ]]; then
+            echo "::notice::No chart changes detected, skipping tagging"
+            echo "charts=" >> "$GITHUB_OUTPUT"
+            echo "has_charts=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "charts=$CHARTS" >> "$GITHUB_OUTPUT"
+          echo "has_charts=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Charts to tag: $CHARTS"
+
+      - name: Find Source PR
+        id: source-pr
+        if: steps.detect.outputs.has_charts == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          PR_NUMBER=$(get_source_pr "${{ github.sha }}")
+
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "::warning::Could not find source PR for commit ${{ github.sha }}"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            echo "attestation_map={}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Source PR: #$PR_NUMBER"
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+            ATTESTATION_MAP=$(extract_attestation_map "$PR_NUMBER")
+            echo "attestation_map=$ATTESTATION_MAP" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Tags
+        id: create-tags
+        if: steps.detect.outputs.has_charts == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          source .github/scripts/attestation-lib.sh
+
+          CHARTS="${{ steps.detect.outputs.charts }}"
+          PR_NUMBER="${{ steps.source-pr.outputs.pr_number }}"
+          ATTESTATION_MAP='${{ steps.source-pr.outputs.attestation_map }}'
+          COMMIT_SHA="${{ github.sha }}"
+
+          CREATED_TAGS=""
+          SKIPPED=""
+          FAILED=false
+
+          for chart in $CHARTS; do
+            echo "::group::Processing $chart"
+
+            CHART_YAML="charts/$chart/Chart.yaml"
+            if [[ ! -f "$CHART_YAML" ]]; then
+              echo "::warning::Chart.yaml not found for $chart, skipping"
+              echo "::endgroup::"
+              continue
+            fi
+
+            VERSION=$(grep '^version:' "$CHART_YAML" | awk '{print $2}' | tr -d '"' | tr -d "'")
+            if [[ -z "$VERSION" ]]; then
+              echo "::error::Could not extract version from $CHART_YAML"
+              FAILED=true
+              echo "::endgroup::"
+              continue
+            fi
+
+            TAG_NAME="${chart}-v${VERSION}"
+            echo "Tag: $TAG_NAME, Version: $VERSION"
+
+            # Check if tag already exists
+            if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+              EXISTING_COMMIT=$(git rev-list -n 1 "$TAG_NAME")
+              if [[ "$EXISTING_COMMIT" == "$COMMIT_SHA" ]]; then
+                echo "::notice::Tag $TAG_NAME already exists at this commit, skipping"
+                SKIPPED="${SKIPPED} ${TAG_NAME}"
+                echo "::endgroup::"
+                continue
+              else
+                echo "::error::Tag $TAG_NAME exists but points to different commit!"
+                echo "::error::This indicates version was not bumped properly."
+                FAILED=true
+                echo "::endgroup::"
+                continue
+              fi
+            fi
+
+            # Extract changelog
+            CHANGELOG=$(extract_changelog_for_version "$chart" "$VERSION")
+
+            # Format attestation lineage
+            if [[ -n "$ATTESTATION_MAP" && "$ATTESTATION_MAP" != "{}" ]]; then
+              ATTESTATION_LINEAGE=$(echo "$ATTESTATION_MAP" | jq -r 'to_entries | .[] | "- \(.key): \(.value)"' 2>/dev/null || echo "- Parse error")
+            else
+              ATTESTATION_LINEAGE="- No attestation data available"
+            fi
+
+            # Create annotated tag
+            git tag -a "$TAG_NAME" -m "$(cat <<EOF
+          Release: $chart v$VERSION
+
+          Attestation Lineage:
+          $ATTESTATION_LINEAGE
+
+          Changelog:
+          $CHANGELOG
+
+          Source PR: #${PR_NUMBER:-unknown}
+          Commit: $COMMIT_SHA
+          EOF
+          )"
+
+            git push origin "$TAG_NAME"
+            echo "::notice::Created and pushed tag: $TAG_NAME"
+
+            # Track created tags
+            if [[ -z "$CREATED_TAGS" ]]; then
+              CREATED_TAGS="$TAG_NAME"
+            else
+              CREATED_TAGS="${CREATED_TAGS},${TAG_NAME}"
+            fi
+
+            echo "::endgroup::"
+          done
+
+          echo "tags_created=$CREATED_TAGS" >> "$GITHUB_OUTPUT"
+          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
+
+          if [[ "$FAILED" == "true" ]]; then
+            echo "::error::One or more tags failed to create"
+            exit 1
+          fi
+
+          if [[ -n "$CREATED_TAGS" ]]; then
+            echo "::notice::Tags created: $CREATED_TAGS"
+            echo "::notice::Release workflow (W6) will trigger for each tag"
+          fi
+
+  # ==========================================================================
+  # Summary
+  # ==========================================================================
+  summary:
+    needs: create-tags
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Summary
+        run: |
+          {
+            echo "## Tag Atomic Chart - Summary"
+            echo ""
+            echo "### Commit"
+            echo "- SHA: ${{ github.sha }}"
+            echo "- Message: ${{ github.event.head_commit.message }}"
+            echo ""
+            echo "### Results"
+            echo "| Phase | Status |"
+            echo "|-------|--------|"
+            echo "| Create Tags | ${{ needs.create-tags.result == 'success' && ':white_check_mark:' || ':x:' }} |"
+            echo ""
+            if [[ -n "${{ needs.create-tags.outputs.tags_created }}" ]]; then
+              echo "### Tags Created"
+              echo "\`\`\`"
+              echo "${{ needs.create-tags.outputs.tags_created }}" | tr ',' '\n'
+              echo "\`\`\`"
+              echo ""
+              echo "> These tags will trigger the Release Atomic Chart (W6) workflow."
+            elif [[ -n "${{ needs.create-tags.outputs.charts }}" ]]; then
+              echo "### No Tags Created"
+              echo "Charts detected: ${{ needs.create-tags.outputs.charts }}"
+              echo "Tags may have been skipped (already exist) or failed to create."
+            else
+              echo "No chart changes detected in this push."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Split the release workflow (W6) into two parts for tag-based triggering:

- **tag-atomic-chart.yaml (W6-Tag)**: Triggers on push to main with `charts/**` changes, creates annotated tags in format `<chart>-v<version>`
- **release-atomic-chart.yaml (W6)**: Now triggers on tag push matching `*-v*` pattern. Validates tag format and chart existence before packaging and publishing.

## Flow

```
Push to main (charts/**) 
    → W6-Tag creates tags 
        → Each tag triggers W6
            → Package → GHCR → GitHub Release → Release Branch
```

## Benefits

- Cleaner separation of concerns (tagging vs releasing)
- Tag-based release verification (validates chart exists before release)
- Support for manual/hotfix tagging
- Better audit trail via annotated tags

## Test plan

- [ ] W1 validation passes
- [ ] Auto-merge to integration works
- [ ] E2E test after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ATTESTATION_MAP
{"commit-validation":"17035393"}
-->