### PR TITLE
fix(cloudflared): apply podLabels from values to pod template

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -1,8 +1,8 @@
 annotations:
   artifacthub.io/alternativeName: cloudflare
   artifacthub.io/changes: |-
-    - kind: added
-      description: Add additional keywords for discoverability (ingress, private-network)
+    - kind: fixed
+      description: Apply podLabels from values to pod template metadata
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: cloudflared

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
       {{- end }}
       labels:
         {{- include "cloudflared.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## Summary

Bug fix: The `podLabels` value was defined in `values.yaml` but not being applied to pod template metadata.

### Problem

Users could set `podLabels` in their values, but these labels were never added to the actual pods because the template was missing the directive to include them.

```yaml
# values.yaml
podLabels:
  app.kubernetes.io/part-of: my-app  # This was being ignored!
```

### Fix

Added the missing template directive to include `podLabels` in the pod template metadata labels, alongside the selector labels.

### Testing

- Chart lints successfully
- Verified template renders correctly with test podLabels

### E2E Testing

This fix will be used for E2E testing of the updated chart release workflows (W1 → W2 → W5 → W6-Tag → W6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ATTESTATION_MAP
{"artifacthub-lint":"17037550"}
-->