### PR TITLE
ci(dependabot): target integration branch and group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "integration"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -11,3 +12,8 @@ updates:
       - "dependencies"
       - "github-actions"
     open-pull-requests-limit: 5
+    groups:
+      # Group all github-actions updates into a single PR
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Update dependabot configuration to work with atomic branching workflow.

### Changes
- **Target branch**: `main` → `integration`
- **Grouping**: All github-actions updates grouped into single PR

### Why
- Dependabot PRs should flow through the same pipeline as other contributions
- Grouping reduces PR noise and allows single atomic PR to main for all dependency updates

### Next Steps (separate PR)
- Update auto-merge workflow to handle dependabot PRs
- Create `ci/dependencies` atomic branch for dependency updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ATTESTATION_MAP
{"commit-validation":"17038942"}
-->