### PR TITLE
fix(dependabot): align labels with repository labels strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,8 @@ updates:
       prefix: "ci"
     labels:
       - "dependencies"
-      - "github-actions"
+      - "cicd"
+      - "automation"
     open-pull-requests-limit: 5
     groups:
       # Group all github-actions updates into a single PR


### PR DESCRIPTION
## Summary

Update dependabot labels to align with the repository labels strategy.

### Changes

| Before | After |
|--------|-------|
| `dependencies` | `dependencies` |
| `github-actions` ❌ | `cicd` ✓ |
| - | `automation` ✓ |

### Why

Per `.claude/memory/repo-labels.md`:
- `github-actions` was migrated to `cicd` (more descriptive)
- `automation` flag should be applied to bot-managed PRs

### Reference
- Labels strategy: `.claude/memory/repo-labels.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ATTESTATION_MAP
{"commit-validation":"17039630"}
-->