### PR TITLE
fix(ci): handle app/dependabot author format in W2 and auto-merge

### DIFF
--- a/.github/workflows/auto-merge-integration.yaml
+++ b/.github/workflows/auto-merge-integration.yaml
@@ -13,7 +13,7 @@
 # Trust Requirements (ALL must pass):
 # 1. PR targets an allowed base branch (configured in ALLOWED_BASE_BRANCHES)
 # 2. Trust check (one of):
-#    a. PR author is dependabot[bot] (trusted GitHub automation)
+#    a. PR author is dependabot (trusted GitHub automation)
 #    b. PR author is listed in CODEOWNERS (trusted contributor)
 # 3. All commits in PR are signed/verified
 #
@@ -129,9 +129,10 @@ jobs:
         run: |
           echo "::group::Detecting PR type"
 
-          if [[ "$PR_AUTHOR" == "dependabot[bot]" ]]; then
+          # Note: API returns "app/dependabot" for dependabot PRs, not "dependabot[bot]"
+          if [[ "$PR_AUTHOR" == "dependabot[bot]" || "$PR_AUTHOR" == "app/dependabot" ]]; then
             echo "pr_type=dependabot" >> "$GITHUB_OUTPUT"
-            echo "::notice::Dependabot PR detected - using automation trust path"
+            echo "::notice::Dependabot PR detected (author: $PR_AUTHOR) - using automation trust path"
           else
             echo "pr_type=contributor" >> "$GITHUB_OUTPUT"
             echo "::notice::Contributor PR detected - using CODEOWNERS trust path"
@@ -153,7 +154,7 @@ jobs:
 
           if [[ "$PR_TYPE" == "dependabot" ]]; then
             # Dependabot is trusted by virtue of being the GitHub app
-            # The author check in detect step already verified it's dependabot[bot]
+            # The author check in detect step already verified it's dependabot
             echo "::notice::Dependabot is a trusted GitHub automation"
             TRUSTED=true
           else

--- a/.github/workflows/create-atomic-chart-pr.yaml
+++ b/.github/workflows/create-atomic-chart-pr.yaml
@@ -156,11 +156,13 @@ jobs:
             echo "pr_number=$SOURCE_PR" >> "$GITHUB_OUTPUT"
 
             # Check if source PR is from dependabot
+            # Note: API returns "app/dependabot" for dependabot PRs, not "dependabot[bot]"
             PR_AUTHOR=$(gh pr view "$SOURCE_PR" --json author --jq '.author.login')
-            if [[ "$PR_AUTHOR" == "dependabot[bot]" ]]; then
-              echo "::notice::Source PR is from dependabot"
+            if [[ "$PR_AUTHOR" == "dependabot[bot]" || "$PR_AUTHOR" == "app/dependabot" ]]; then
+              echo "::notice::Source PR is from dependabot (author: $PR_AUTHOR)"
               echo "is_dependabot=true" >> "$GITHUB_OUTPUT"
             else
+              echo "::notice::Source PR author: $PR_AUTHOR (not dependabot)"
               echo "is_dependabot=false" >> "$GITHUB_OUTPUT"
             fi
 


### PR DESCRIPTION
## Summary
- Fix dependabot author detection in W2 and auto-merge workflows
- GitHub API returns `app/dependabot`, not `dependabot[bot]` as expected

## Problem
The `process-dependencies` job in W2 was being skipped for all dependabot PRs because the author check was looking for `dependabot[bot]` but the API returns `app/dependabot`.

## Changes
- Update W2 (`create-atomic-chart-pr.yaml`) to check for both author formats
- Update auto-merge workflow to check for both author formats
- Add logging to show actual author value for debugging

## Test Plan
- [ ] PR passes W1 validation
- [ ] After merge, re-run W2 manually to verify process-dependencies job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ATTESTATION_MAP
{"commit-validation":"17039861"}
-->