### PR TITLE
fix(w2): compare against target branch for change detection

### DIFF
--- a/.github/workflows/create-atomic-chart-pr.yaml
+++ b/.github/workflows/create-atomic-chart-pr.yaml
@@ -79,16 +79,10 @@ jobs:
         run: |
           source .github/scripts/attestation-lib.sh
 
-          # Handle both squash merges and merge commits
-          if git rev-parse HEAD^2 >/dev/null 2>&1; then
-            # Merge commit - compare against first parent
-            RANGE="HEAD^..HEAD"
-            echo "::notice::Detected merge commit, using range: $RANGE"
-          else
-            # Squash merge or regular commit
-            RANGE="HEAD~1..HEAD"
-            echo "::notice::Detected squash/regular commit, using range: $RANGE"
-          fi
+          # Compare against target branch to detect ALL changes needing atomization
+          # This ensures we don't miss changes when multiple commits merge in sequence
+          RANGE="origin/${TARGET_BRANCH}..HEAD"
+          echo "::notice::Detecting changes using range: $RANGE"
 
           # Get all changed files
           CHANGED_FILES=$(git diff --name-only "$RANGE")


### PR DESCRIPTION
## Summary
- Fix change detection to compare against target branch instead of just last commit
- Prevents missing changes when multiple commits merge in sequence

## Problem
The W2 workflow only checked `HEAD~1..HEAD` for changes. This failed when:
1. A chart change merges to integration
2. A CI-only change merges afterward
3. The workflow triggers on the CI commit
4. No charts are detected because only the last commit is checked

## Solution
Compare `origin/${TARGET_BRANCH}..HEAD` instead, which detects ALL changes between the target branch (main) and current HEAD.

## Related
- Upstream fix: aRustyDev/gh#18, aRustyDev/gh#20
- Fixes #163