### PR TITLE
fix(w2): update to atomic-release-v0.1.1

### DIFF
--- a/.github/workflows/create-atomic-chart-pr.yaml
+++ b/.github/workflows/create-atomic-chart-pr.yaml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   atomize:
-    uses: aRustyDev/gh/.github/workflows/atomic-release-atomize-changes.yml@atomic-release-v0.1.0
+    uses: aRustyDev/gh/.github/workflows/atomic-release-atomize-changes.yml@atomic-release-v0.1.1
     with:
       artifact_path: "charts"
       manifest_file: "Chart.yaml"


### PR DESCRIPTION
## Summary
Update reusable workflow reference to use the fixed version.

## Changes
- Update from `@atomic-release-v0.1.0` to `@atomic-release-v0.1.1`
- v0.1.1 fixes the change detection to compare against target branch instead of just last commit

## Related
- aRustyDev/gh#18 (bug)
- aRustyDev/gh#20 (fix PR)

<!-- ATTESTATION_MAP
{"commit-validation":"17466841"}
-->