### PR TITLE
feat(test-workflow): add E2E-2 service annotations feature

### DIFF
--- a/charts/test-workflow/templates/e2e-2-configmap.yaml
+++ b/charts/test-workflow/templates/e2e-2-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.e2e2.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "test-workflow.fullname" . }}-e2e-2
+  labels:
+    {{- include "test-workflow.labels" . | nindent 4 }}
+    e2e-test: "2"
+data:
+  prometheus-scrape: {{ .Values.e2e2.serviceAnnotations | toJson | quote }}
+{{- end }}

--- a/charts/test-workflow/values.yaml
+++ b/charts/test-workflow/values.yaml
@@ -14,6 +14,14 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 80
+  annotations: {}
+
+# E2E-2 Test: Service annotations feature
+e2e2:
+  enabled: false
+  serviceAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "80"
 
 resources: {}
 


### PR DESCRIPTION
## Summary
E2E-2 test: Add service annotations feature to test-workflow chart.

## Changes
- Add `e2e2` configuration section in values.yaml
- Add `e2e-2-configmap.yaml` template
- Supports Prometheus scraping annotations

## Purpose
Verify the full pipeline works after W2 change detection fix:
1. W1: Validate contribution
2. Auto-merge to integration
3. W2: Atomize to `charts/test-workflow` branch
4. W5: Validate and bump version
5. W6: Release

<!-- ATTESTATION_MAP
{"commit-validation":"17467313"}
-->