### PR TITLE
fix(w2): update to atomic-release-v0.1.2

### DIFF
--- a/.github/workflows/create-atomic-chart-pr.yaml
+++ b/.github/workflows/create-atomic-chart-pr.yaml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   atomize:
-    uses: aRustyDev/gh/.github/workflows/atomic-release-atomize-changes.yml@atomic-release-v0.1.1
+    uses: aRustyDev/gh/.github/workflows/atomic-release-atomize-changes.yml@atomic-release-v0.1.2
     with:
       artifact_path: "charts"
       manifest_file: "Chart.yaml"


### PR DESCRIPTION
Update to v0.1.2 which fixes JSON validation for attestation map parsing.

<!-- ATTESTATION_MAP
{"commit-validation":"17467608"}
-->