### PR TITLE
feat(test-workflow): add metrics and monitoring configuration

### DIFF
--- a/charts/test-workflow/templates/e2e-1-metrics-configmap.yaml
+++ b/charts/test-workflow/templates/e2e-1-metrics-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "test-workflow.fullname" . }}-metrics
+  labels:
+    {{- include "test-workflow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+data:
+  METRICS_ENABLED: "true"
+  METRICS_PORT: {{ .Values.metrics.port | quote }}
+  METRICS_PATH: {{ .Values.metrics.path | quote }}
+{{- end }}

--- a/charts/test-workflow/values.yaml
+++ b/charts/test-workflow/values.yaml
@@ -43,3 +43,13 @@ e2e3:
     path: "/health"
     port: 8080
     initialDelaySeconds: 10
+
+# E2E-1 Test: Metrics and monitoring configuration
+metrics:
+  enabled: false
+  port: 9090
+  path: "/metrics"
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9090"
+    prometheus.io/path: "/metrics"


### PR DESCRIPTION
## Summary

Add metrics ConfigMap feature for E2E-1 workflow testing:
- New metrics configuration in values.yaml
- Prometheus-compatible annotations
- Configurable port and path

## E2E-1 Test Checklist

This PR tests the full chart release pipeline:

- [ ] W1 (Validate Contribution PR) passes
- [ ] Auto-merge enables (trusted + verified)
- [ ] PR merges to integration
- [ ] W2 creates `charts/test-workflow` branch + PR to main
- [ ] W5 runs validation + bumps version (0.1.2 → 0.2.0)
- [ ] Merge PR to main
- [ ] Release workflow creates tag + publishes

## Expected Outcome

- Version bumped from 0.1.2 → 0.2.0
- Tag `test-workflow-v0.2.0` created
- Package in GHCR with Cosign signature
- GitHub Release created with attestation

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- ATTESTATION_MAP
{"artifacthub-lint":"17583154"}
-->